### PR TITLE
Adjust opt-out strategy

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -110,7 +110,7 @@ class ValidateImplement(Task):
             if "momconnect_prebirth" in messageset["short_name"]:
                 has_active_momconnect_prebirth_sub = True
                 lang = active_sub["lang"]
-            if "nurseconnect" not in messageset["short_name"]:
+            if "prebirth" in messageset["short_name"]:
                 self.l.info("Deactivating subscription")
                 sbm_client.update_subscription(
                     active_sub["id"], {"active": False})
@@ -175,6 +175,7 @@ class ValidateImplement(Task):
         """
         self.l.info("Starting PMTCT switch to loss")
         self.deactivate_all_except_nurseconnect(change)
+        # Future: Create subscription to loss messages
         self.l.info("Completed PMTCT switch to loss")
         return "Completed PMTCT switch to loss"
 
@@ -227,10 +228,10 @@ class ValidateImplement(Task):
         app, we're only deactivating the subscriptions here. Note this only
         deactivates the NurseConnect subscription.
         """
-        self.l.info("Starting CurseConnect optout")
+        self.l.info("Starting NurseConnect optout")
         self.deactivate_nurseconnect(change)
-        self.l.info("Completed CurseConnect optout")
-        return "Completed CurseConnect optout"
+        self.l.info("Completed NurseConnect optout")
+        return "Completed NurseConnect optout"
 
     def momconnect_loss_switch(self, change):
         """ Deactivate any active momconnect & pmtct subscriptions, then

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -65,6 +65,23 @@ class ValidateImplement(Task):
         self.l.info("Non-nurseconnect subscriptions deactivated")
         return True
 
+    def deactivate_nurseconnect(self, change):
+        """ Deactivates nurseconnect subscription only
+        """
+        self.l.info("Retrieving nurseconnect messageset id")
+        messageset = sbm_client.get_messagesets(
+            {"short_name": "nurseconnect.hw_full.1"})["results"][0]
+
+        self.l.info("Retrieving active nurseconnect subscriptions")
+        active_subs = sbm_client.get_subscriptions({
+            'id': change.registrant_id, 'active': True,
+            'messageset': messageset["id"]}
+        )["results"]
+
+        self.l.info("Deactivating active nurseconnect subscriptions")
+        for active_sub in active_subs:
+            sbm_client.update_subscription(active_sub["id"], {"active": False})
+
     # Action implementation
     def baby_switch(self, change):
         """ This should be applied when a mother has her baby. Currently it
@@ -173,9 +190,7 @@ class ValidateImplement(Task):
         handle sending the information update to Jembi
         """
         self.l.info("Starting nurseconnect msisdn change")
-
         self.l.info("Completed nurseconnect msisdn change")
-
         return "NurseConnect msisdn changed"
 
     def nurse_optout(self, change):
@@ -184,25 +199,10 @@ class ValidateImplement(Task):
         app, we're only deactivating the subscriptions here. Note this only
         deactivates the NurseConnect subscription.
         """
-        self.l.info("Starting nurseconnect optout")
-
-        self.l.info("Retrieving nurseconnect messageset id")
-        messageset = sbm_client.get_messagesets(
-            {"short_name": "nurseconnect.hw_full.1"})["results"][0]
-
-        self.l.info("Retrieving active nurseconnect subscriptions")
-        active_subs = sbm_client.get_subscriptions({
-            'id': change.registrant_id, 'active': True,
-            'messageset': messageset["id"]}
-        )["results"]
-
-        self.l.info("Deactivating active nurseconnect subscriptions")
-        for active_sub in active_subs:
-            sbm_client.update_subscription(active_sub["id"], {"active": False})
-
-        self.l.info("NurseConnect optout completed")
-
-        return "Nurse optout completed"
+        self.l.info("Starting CurseConnect optout")
+        self.deactivate_nurseconnect(change)
+        self.l.info("Completed CurseConnect optout")
+        return "Completed CurseConnect optout"
 
     def momconnect_loss_switch(self, change):
         """ Deactivate any active momconnect & pmtct subscriptions, then

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -22,9 +22,9 @@ def override_get_today():
     return datetime.datetime.strptime("20150817", "%Y%m%d")
 
 
-def mock_get_active_subscriptions(registrant_id):
-    subscription_id_1 = "subscription1-4bf1-8779-c47b428e89d0"
-    subscription_id_2 = "subscription2-4bf1-8779-c47b428e89d0"
+def mock_get_active_subs_mc_pmtct(registrant_id):
+    pmtct_prebirth_sub_id = "subscription1-4bf1-8779-c47b428e89d0"
+    momconnect_prebirth_sub_id = "subscription2-4bf1-8779-c47b428e89d0"
     responses.add(
         responses.GET,
         'http://sbm/api/v1/subscriptions/?active=True&id=%s' % registrant_id,
@@ -34,13 +34,13 @@ def mock_get_active_subscriptions(registrant_id):
             "previous": None,
             "results": [
                 {   # pmtct_prebirth.patient.1 subscription
-                    "id": subscription_id_1,
+                    "id": pmtct_prebirth_sub_id,
                     "identity": registrant_id,
                     "active": True,
                     "completed": False,
                     "lang": "eng_ZA",
                     "url": "http://sbm/api/v1/subscriptions/%s" % (
-                        subscription_id_1),
+                        pmtct_prebirth_sub_id),
                     "messageset": 11,
                     "next_sequence_number": 11,
                     "schedule": 101,
@@ -51,13 +51,13 @@ def mock_get_active_subscriptions(registrant_id):
                     "updated_at": "2015-07-10T06:13:29.693272Z"
                 },
                 {   # momconnect_prebirth.hw_full.1 subscription
-                    "id": subscription_id_2,
+                    "id": momconnect_prebirth_sub_id,
                     "identity": registrant_id,
                     "active": True,
                     "completed": False,
                     "lang": "eng_ZA",
                     "url": "http://sbm/api/v1/subscriptions/%s" % (
-                        subscription_id_2),
+                        momconnect_prebirth_sub_id),
                     "messageset": 21,
                     "next_sequence_number": 21,
                     "schedule": 121,
@@ -73,7 +73,43 @@ def mock_get_active_subscriptions(registrant_id):
         match_querystring=True
     )
 
-    return [subscription_id_1, subscription_id_2]
+    return [pmtct_prebirth_sub_id, momconnect_prebirth_sub_id]
+
+
+def mock_get_active_subs_mc(registrant_id):
+    momconnect_prebirth_sub_id = "subscription2-4bf1-8779-c47b428e89d0"
+    responses.add(
+        responses.GET,
+        'http://sbm/api/v1/subscriptions/?active=True&id=%s' % registrant_id,
+        json={
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "results": [
+                {   # momconnect_prebirth.hw_full.1 subscription
+                    "id": momconnect_prebirth_sub_id,
+                    "identity": registrant_id,
+                    "active": True,
+                    "completed": False,
+                    "lang": "eng_ZA",
+                    "url": "http://sbm/api/v1/subscriptions/%s" % (
+                        momconnect_prebirth_sub_id),
+                    "messageset": 21,
+                    "next_sequence_number": 21,
+                    "schedule": 121,
+                    "process_status": 0,
+                    "version": 1,
+                    "metadata": {},
+                    "created_at": "2015-07-10T06:13:29.693272Z",
+                    "updated_at": "2015-07-10T06:13:29.693272Z"
+                }
+            ],
+        },
+        status=200, content_type='application/json',
+        match_querystring=True
+    )
+
+    return [momconnect_prebirth_sub_id]
 
 
 def mock_get_active_subscriptions_none(registrant_id):
@@ -1037,13 +1073,14 @@ class TestChangeValidation(AuthenticatedAPITestCase):
 class TestChangeActions(AuthenticatedAPITestCase):
 
     @responses.activate
-    def test_baby_switch_with_active_pmtct_subscription(self):
+    def test_baby_switch_momconnect_and_pmtct_subs(self):
         # Pretest
         self.assertEqual(Registration.objects.all().count(), 0)
         # Setup
-        # make registration
+        # make registrations
+        self.make_registration_momconnect_prebirth()
         self.make_registration_pmtct_prebirth()
-        self.assertEqual(Registration.objects.all().count(), 1)
+        self.assertEqual(Registration.objects.all().count(), 2)
         self.assertEqual(SubscriptionRequest.objects.all().count(), 0)
         # make change object
         change_data = {
@@ -1054,8 +1091,8 @@ class TestChangeActions(AuthenticatedAPITestCase):
         }
         change = Change.objects.create(**change_data)
 
-        # . mock get subscription request
-        active_subscription_ids = mock_get_active_subscriptions(
+        # . mock get subscriptions request
+        active_subscription_ids = mock_get_active_subs_mc_pmtct(
             change_data["registrant_id"])
 
         # . mock get messageset by id
@@ -1082,8 +1119,51 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change.refresh_from_db()
         self.assertEqual(result.get(), True)
         self.assertEqual(change.validated, True)
-        self.assertEqual(Registration.objects.all().count(), 1)
+        self.assertEqual(Registration.objects.all().count(), 2)
         self.assertEqual(SubscriptionRequest.objects.all().count(), 2)
+
+    @responses.activate
+    def test_baby_switch_only_momconnect_sub(self):
+        # Pretest
+        self.assertEqual(Registration.objects.all().count(), 0)
+        # Setup
+        # make registrations
+        self.make_registration_momconnect_prebirth()
+        self.assertEqual(Registration.objects.all().count(), 1)
+        self.assertEqual(SubscriptionRequest.objects.all().count(), 0)
+        # make change object
+        change_data = {
+            "registrant_id": "mother01-63e2-4acc-9b94-26663b9bc267",
+            "action": "baby_switch",
+            "data": {},
+            "source": self.make_source_normaluser()
+        }
+        change = Change.objects.create(**change_data)
+
+        # . mock get subscriptions request
+        active_subscription_ids = mock_get_active_subs_mc(
+            change_data["registrant_id"])
+
+        # . mock get messageset by id
+        utils_tests.mock_get_messageset(21)
+
+        # . mock deactivate active subscriptions
+        mock_deactivate_subscriptions(active_subscription_ids)
+
+        # . mock get momconnect_postrbirh messageset by shortname
+        schedule_id = utils_tests.mock_get_messageset_by_shortname(
+            "momconnect_postbirth.hw_full.1")
+        utils_tests.mock_get_schedule(schedule_id)
+
+        # Execute
+        result = validate_implement.apply_async(args=[change.id])
+
+        # Check
+        change.refresh_from_db()
+        self.assertEqual(result.get(), True)
+        self.assertEqual(change.validated, True)
+        self.assertEqual(Registration.objects.all().count(), 1)
+        self.assertEqual(SubscriptionRequest.objects.all().count(), 1)
 
     @responses.activate
     def test_pmtct_loss_switch(self):
@@ -1105,7 +1185,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subscriptions(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1144,7 +1224,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subscriptions(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1182,7 +1262,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subscriptions(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1316,7 +1396,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subscriptions(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct(
             change_data["registrant_id"])
 
         # . mock deactivate active subscriptions
@@ -1401,7 +1481,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subscriptions(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1440,7 +1520,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subscriptions(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -1065,9 +1065,14 @@ class TestChangeActions(AuthenticatedAPITestCase):
         # . mock deactivate active subscriptions
         mock_deactivate_subscriptions(active_subscription_ids)
 
-        # . mock get messageset by shortname
+        # . mock get pmtct_postbirth messageset by shortname
         schedule_id = utils_tests.mock_get_messageset_by_shortname(
             "pmtct_postbirth.patient.1")
+        utils_tests.mock_get_schedule(schedule_id)
+
+        # . mock get momconnect_postrbirh messageset by shortname
+        schedule_id = utils_tests.mock_get_messageset_by_shortname(
+            "momconnect_postbirth.hw_full.1")
         utils_tests.mock_get_schedule(schedule_id)
 
         # Execute
@@ -1078,7 +1083,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(result.get(), True)
         self.assertEqual(change.validated, True)
         self.assertEqual(Registration.objects.all().count(), 1)
-        self.assertEqual(SubscriptionRequest.objects.all().count(), 1)
+        self.assertEqual(SubscriptionRequest.objects.all().count(), 2)
 
     @responses.activate
     def test_pmtct_loss_switch(self):

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -22,15 +22,16 @@ def override_get_today():
     return datetime.datetime.strptime("20150817", "%Y%m%d")
 
 
-def mock_get_active_subs_mc_pmtct_nc(registrant_id):
+def mock_get_active_subs_mcpre_mcpost_pmtct_nc(registrant_id):
     pmtct_prebirth_sub_id = "subscription1-4bf1-8779-c47b428e89d0"
     momconnect_prebirth_sub_id = "subscription2-4bf1-8779-c47b428e89d0"
     nurseconnect_sub_id = "subscription3-4bf1-8779-c47b428e89d0"
+    momconnect_postbirth_sub_id = "subscription4-4bf1-8779-c47b428e89d0"
     responses.add(
         responses.GET,
         'http://sbm/api/v1/subscriptions/?active=True&id=%s' % registrant_id,
         json={
-            "count": 2,
+            "count": 4,
             "next": None,
             "previous": None,
             "results": [
@@ -84,7 +85,24 @@ def mock_get_active_subs_mc_pmtct_nc(registrant_id):
                     "metadata": {},
                     "created_at": "2015-07-10T06:13:29.693272Z",
                     "updated_at": "2015-07-10T06:13:29.693272Z"
-                }
+                },
+                {   # momconnect_postbirth.hw_full.1 subscription
+                    "id": momconnect_postbirth_sub_id,
+                    "identity": registrant_id,
+                    "active": True,
+                    "completed": False,
+                    "lang": "eng_ZA",
+                    "url": "http://sbm/api/v1/subscriptions/%s" % (
+                        momconnect_postbirth_sub_id),
+                    "messageset": 32,
+                    "next_sequence_number": 32,
+                    "schedule": 132,
+                    "process_status": 0,
+                    "version": 1,
+                    "metadata": {},
+                    "created_at": "2015-07-10T06:13:29.693272Z",
+                    "updated_at": "2015-07-10T06:13:29.693272Z"
+                },
             ],
         },
         status=200, content_type='application/json',
@@ -92,7 +110,7 @@ def mock_get_active_subs_mc_pmtct_nc(registrant_id):
     )
 
     return [pmtct_prebirth_sub_id, momconnect_prebirth_sub_id,
-            nurseconnect_sub_id]
+            nurseconnect_sub_id, momconnect_postbirth_sub_id]
 
 
 def mock_get_active_subs_mc(registrant_id):
@@ -1111,12 +1129,13 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscriptions request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
+        active_subscription_ids = mock_get_active_subs_mcpre_mcpost_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by id
         utils_tests.mock_get_messageset(11)
         utils_tests.mock_get_messageset(21)
+        utils_tests.mock_get_messageset(32)
         utils_tests.mock_get_messageset(61)
 
         # . mock deactivate active subscriptions
@@ -1205,7 +1224,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
+        active_subscription_ids = mock_get_active_subs_mcpre_mcpost_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1244,7 +1263,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
+        active_subscription_ids = mock_get_active_subs_mcpre_mcpost_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1282,7 +1301,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
+        active_subscription_ids = mock_get_active_subs_mcpre_mcpost_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1416,7 +1435,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
+        active_subscription_ids = mock_get_active_subs_mcpre_mcpost_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock deactivate active subscriptions
@@ -1501,7 +1520,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
+        active_subscription_ids = mock_get_active_subs_mcpre_mcpost_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1540,7 +1559,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
+        active_subscription_ids = mock_get_active_subs_mcpre_mcpost_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -22,9 +22,10 @@ def override_get_today():
     return datetime.datetime.strptime("20150817", "%Y%m%d")
 
 
-def mock_get_active_subs_mc_pmtct(registrant_id):
+def mock_get_active_subs_mc_pmtct_nc(registrant_id):
     pmtct_prebirth_sub_id = "subscription1-4bf1-8779-c47b428e89d0"
     momconnect_prebirth_sub_id = "subscription2-4bf1-8779-c47b428e89d0"
+    nurseconnect_sub_id = "subscription3-4bf1-8779-c47b428e89d0"
     responses.add(
         responses.GET,
         'http://sbm/api/v1/subscriptions/?active=True&id=%s' % registrant_id,
@@ -66,6 +67,23 @@ def mock_get_active_subs_mc_pmtct(registrant_id):
                     "metadata": {},
                     "created_at": "2015-07-10T06:13:29.693272Z",
                     "updated_at": "2015-07-10T06:13:29.693272Z"
+                },
+                {   # nurseconnect.hw_full.1 subscription
+                    "id": nurseconnect_sub_id,
+                    "identity": registrant_id,
+                    "active": True,
+                    "completed": False,
+                    "lang": "eng_ZA",
+                    "url": "http://sbm/api/v1/subscriptions/%s" % (
+                        nurseconnect_sub_id),
+                    "messageset": 61,
+                    "next_sequence_number": 6,
+                    "schedule": 161,
+                    "process_status": 0,
+                    "version": 1,
+                    "metadata": {},
+                    "created_at": "2015-07-10T06:13:29.693272Z",
+                    "updated_at": "2015-07-10T06:13:29.693272Z"
                 }
             ],
         },
@@ -73,7 +91,8 @@ def mock_get_active_subs_mc_pmtct(registrant_id):
         match_querystring=True
     )
 
-    return [pmtct_prebirth_sub_id, momconnect_prebirth_sub_id]
+    return [pmtct_prebirth_sub_id, momconnect_prebirth_sub_id,
+            nurseconnect_sub_id]
 
 
 def mock_get_active_subs_mc(registrant_id):
@@ -1073,7 +1092,7 @@ class TestChangeValidation(AuthenticatedAPITestCase):
 class TestChangeActions(AuthenticatedAPITestCase):
 
     @responses.activate
-    def test_baby_switch_momconnect_and_pmtct_subs(self):
+    def test_baby_switch_momconnect_pmtct_nurseconnect_subs(self):
         # Pretest
         self.assertEqual(Registration.objects.all().count(), 0)
         # Setup
@@ -1092,12 +1111,13 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscriptions request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by id
         utils_tests.mock_get_messageset(11)
         utils_tests.mock_get_messageset(21)
+        utils_tests.mock_get_messageset(61)
 
         # . mock deactivate active subscriptions
         mock_deactivate_subscriptions(active_subscription_ids)
@@ -1123,7 +1143,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(SubscriptionRequest.objects.all().count(), 2)
 
     @responses.activate
-    def test_baby_switch_only_momconnect_sub(self):
+    def test_baby_switch_momconnect_only_sub(self):
         # Pretest
         self.assertEqual(Registration.objects.all().count(), 0)
         # Setup
@@ -1185,7 +1205,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1224,7 +1244,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1262,7 +1282,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1396,7 +1416,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock deactivate active subscriptions
@@ -1481,7 +1501,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname
@@ -1520,7 +1540,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         change = Change.objects.create(**change_data)
 
         # . mock get subscription request
-        active_subscription_ids = mock_get_active_subs_mc_pmtct(
+        active_subscription_ids = mock_get_active_subs_mc_pmtct_nc(
             change_data["registrant_id"])
 
         # . mock get messageset by shortname

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -1318,9 +1318,16 @@ class TestChangeActions(AuthenticatedAPITestCase):
         mock_deactivate_subscriptions(active_subscription_ids)
 
         # . mock get messageset by shortname
+        utils_tests.mock_get_messageset_by_shortname("nurseconnect.hw_full.1")
+
+        # . mock get messageset by shortname
         schedule_id = utils_tests.mock_get_messageset_by_shortname(
             "loss_miscarriage.patient.1")
         utils_tests.mock_get_schedule(schedule_id)
+
+        # . mock get identity by id
+        utils_tests.mock_get_identity_by_id(
+            "mother01-63e2-4acc-9b94-26663b9bc267")
 
         # Execute
         result = validate_implement.apply_async(args=[change.id])
@@ -1392,6 +1399,9 @@ class TestChangeActions(AuthenticatedAPITestCase):
         active_subscription_ids = mock_get_active_subscriptions(
             change_data["registrant_id"])
 
+        # . mock get messageset by shortname
+        utils_tests.mock_get_messageset_by_shortname("nurseconnect.hw_full.1")
+
         # . mock deactivate active subscriptions
         mock_deactivate_subscriptions(active_subscription_ids)
 
@@ -1427,6 +1437,9 @@ class TestChangeActions(AuthenticatedAPITestCase):
         # . mock get subscription request
         active_subscription_ids = mock_get_active_subscriptions(
             change_data["registrant_id"])
+
+        # . mock get messageset by shortname
+        utils_tests.mock_get_messageset_by_shortname("nurseconnect.hw_full.1")
 
         # . mock deactivate active subscriptions
         mock_deactivate_subscriptions(active_subscription_ids)

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -1103,6 +1103,9 @@ class TestChangeActions(AuthenticatedAPITestCase):
         active_subscription_ids = mock_get_active_subscriptions(
             change_data["registrant_id"])
 
+        # . mock get messageset by shortname
+        utils_tests.mock_get_messageset_by_shortname("nurseconnect.hw_full.1")
+
         # . mock deactivate active subscriptions
         mock_deactivate_subscriptions(active_subscription_ids)
 
@@ -1139,6 +1142,9 @@ class TestChangeActions(AuthenticatedAPITestCase):
         active_subscription_ids = mock_get_active_subscriptions(
             change_data["registrant_id"])
 
+        # . mock get messageset by shortname
+        utils_tests.mock_get_messageset_by_shortname("nurseconnect.hw_full.1")
+
         # . mock deactivate active subscriptions
         mock_deactivate_subscriptions(active_subscription_ids)
 
@@ -1173,6 +1179,9 @@ class TestChangeActions(AuthenticatedAPITestCase):
         # . mock get subscription request
         active_subscription_ids = mock_get_active_subscriptions(
             change_data["registrant_id"])
+
+        # . mock get messageset by shortname
+        utils_tests.mock_get_messageset_by_shortname("nurseconnect.hw_full.1")
 
         # . mock deactivate active subscriptions
         mock_deactivate_subscriptions(active_subscription_ids)

--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -7,7 +7,8 @@ def mock_get_identity_by_id(identity_id):
         "id": identity_id,
         "version": 1,
         "details": {
-            "foo": "bar"
+            "foo": "bar",
+            "lang_code": "afr_ZA"
         },
         "communicate_through": None,
         "operator": None,


### PR DESCRIPTION
When you use SMS (Stop):
- [x] Set number to opted out
- [x] Deactivate all subscriptions for the identity

When you use USSD:
- [x] Do not set number to opted out
- [x] Nurseconnect optout deactivates nurseconnect subscription only
- [x] Momconnect and pmtct optouts deactivate pmtct and momconnect subscriptions, not nurseconnect

Also does an amazing thing for baby switch that caters for current and migrated pmtct app versions.