### PR TITLE
Fix admin search - to_addr is not a valid field

### DIFF
--- a/registrations/admin.py
+++ b/registrations/admin.py
@@ -7,7 +7,7 @@ class RegistrationAdmin(admin.ModelAdmin):
         "id", "reg_type", "validated", "registrant_id", "source",
         "created_at", "updated_at", "created_by", "updated_by"]
     list_filter = ["source", "validated", "created_at"]
-    search_fields = ["registrant_id", "to_addr"]
+    search_fields = ["registrant_id", "data"]
 
 
 class SubscriptionRequestAdmin(admin.ModelAdmin):


### PR DESCRIPTION
This currently breaks searching in the django admin.