### PR TITLE
Notify jembi of baby loss change

### DIFF
--- a/changes/management/commands/jembi_submit_babyloss.py
+++ b/changes/management/commands/jembi_submit_babyloss.py
@@ -1,0 +1,59 @@
+from uuid import UUID
+from django.core.management import BaseCommand, CommandError
+from django.utils.dateparse import parse_datetime
+
+
+class Command(BaseCommand):
+
+    help = ("Submit babyloss to Jembi. This command is useful if for "
+            "some reason babyloss weren't submitted or failed to submit "
+            "and need to be submitted again")
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--since', type=parse_datetime,
+            help='Filter for created_at since (required YYYY-MM-DD HH:MM:SS)')
+        parser.add_argument(
+            '--until', type=parse_datetime,
+            help='Filter for created_at until (required YYYY-MM-DD HH:MM:SS)')
+        parser.add_argument(
+            '--source', type=int, default=None,
+            help='The source to limit registrations to.')
+        parser.add_argument(
+            '--change', type=UUID, nargs='+', default=None,
+            help=('UUIDs for babyloss` to fire manually. Use if finer '
+                  'controls are needed than `since` and `until` date ranges.'))
+
+    def handle(self, *args, **options):
+        from changes.models import Change
+        from changes.tasks import push_momconnect_babyloss_to_jembi
+        since = options['since']
+        until = options['until']
+        source = options['source']
+        change_uuids = options['change']
+
+        if not (all([since, until]) or change_uuids):
+            raise CommandError(
+                'At a minimum please specify --since and --until '
+                'or use --change to specify one or more changes')
+
+        changes = Change.objects.filter(validated=True)
+
+        if since and until:
+            changes = changes.filter(
+                created_at__gte=since,
+                created_at__lte=until)
+
+        if source is not None:
+            changes = changes.filter(source__pk=source)
+
+        if change_uuids is not None:
+            changes = changes.filter(pk__in=change_uuids)
+
+        self.stdout.write(
+            'Submitting %s changes.' % (changes.count(),))
+        for change in changes.filter(action__in=(
+                'pmtct_loss_switch', 'momconnect_loss_switch')):
+            push_momconnect_babyloss_to_jembi.delay(str(change.pk))
+            self.stdout.write(str(change.pk))
+        self.stdout.write('Done.')

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -321,6 +321,7 @@ class ValidateImplement(Task):
 
         if switched is True:
             self.l.info("Completed MomConnect switch to loss")
+            push_momconnect_babyloss_to_jembi.delay(str(change.pk))
             return "Completed MomConnect switch to loss"
         else:
             self.l.info("Aborted MomConnect switch to loss")

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -1328,8 +1328,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(SubscriptionRequest.objects.all().count(), 1)
         self.assertEqual(len(responses.calls), 10)
 
-        print json.loads(responses.calls[-1].request.body)
-
         # Check Jembi POST
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
             'cmsisdn': '+27821112222',


### PR DESCRIPTION
This adds functionality that will send a payload to jembi when a baby loss change is created.

Also, a management command to resubmit any missed changes