### PR TITLE
Support for encdate to 3rd party registrations

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -61,6 +61,7 @@ class ThirdPartyRegistrationSerializer(serializers.Serializer):
     consent = serializers.BooleanField()
     mha = serializers.IntegerField(required=False)
     swt = serializers.IntegerField(required=False)
+    encdate = serializers.CharField(required=False)
 
 
 class JembiHelpdeskOutgoingSerializer(serializers.Serializer):

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -542,7 +542,7 @@ class PushRegistrationToJembi(BasePushRegistrationToJembi, Task):
             "type": self.get_subscription_type(authority),
             "lang": self.transform_language_code(
                 registration.data['language']),
-            "encdate": self.get_timestamp(),
+            "encdate": registration.data.get('encdate', self.get_timestamp()),
             "faccode": registration.data.get('faccode'),
             "dob": (self.get_dob(
                 datetime.strptime(registration.data['mom_dob'], '%Y-%m-%d'))

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1036,7 +1036,8 @@ class TestThirdPartyRegistrationAPI(AuthenticatedAPITestCase):
             "authority": "chw",
             "consent": True,
             "mha": 2,
-            "swt": 3
+            "swt": 3,
+            "encdate": "20160101000001",
         }
         # Execute
         response = self.partialclient.post('/api/v1/extregistration/',

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1052,6 +1052,7 @@ class TestThirdPartyRegistrationAPI(AuthenticatedAPITestCase):
         self.assertEqual(d.registrant_id,
                          "02144938-847d-4d2c-9daf-707cb864d077")
         self.assertEqual(d.data['edd'], '2016-11-05')
+        self.assertEqual(d.data['encdate'], '20160101000001')
 
     @responses.activate
     def test_create_third_party_registration_new_identity(self):

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -360,6 +360,8 @@ class ThirdPartyRegistration(APIView):
                 'mha': serializer.validated_data.get('mha', 1),
                 'swt': serializer.validated_data.get('swt', 1),
             }
+            if 'encdate' in serializer.validated_data:
+                reg_data['encdate'] = serializer.validated_data['encdate']
             if id_type == 'sa_id':
                 reg_data['sa_id_no'] = (
                     serializer.validated_data['mom_id_no'])


### PR DESCRIPTION
This PR adds the optional field "encdate" to the 3rd party integrations, if it is not included in the payload the old functionality will apply(get_timestamp).

The reason for this change is to make the "encdate" field more accurate when sending historical registrations to the hub.