### PR TITLE
Use idenity msisdn for the device msisdn

### DIFF
--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -570,7 +570,7 @@ class PushRegistrationToJembi(BasePushRegistrationToJembi, Task):
         # Self registrations on all lines should use cmsisdn as dmsisdn too
         if registration.data.get('msisdn_device') is None:
             json_template["dmsisdn"] = registration.data.get(
-                'msisdn_registrant')
+                'msisdn_registrant', id_msisdn)
 
         if authority == 'clinic':
             json_template["edd"] = datetime.strptime(

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -2297,7 +2297,7 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
             'lang': 'en',
             'dob': '19990127',
             'cmsisdn': '+8108015001051',
-            'dmsisdn': None,
+            'dmsisdn': '+8108015001051',
             'faccode': '123456',
             'id': '8108015001051^^^ZAF^TEL',
             'encdate': '20160101000000',


### PR DESCRIPTION
The dmsisdn field is also a required field on Jembi, so we are also populating it with the msisdn we get from the identity store if we don't have one on the registration.

I tested this payload manually and it worked on their QA system.