### PR TITLE
Command to fix unvalidated PMTCT optouts

### DIFF
--- a/registrations/management/commands/fix_pmtct_registrations.py
+++ b/registrations/management/commands/fix_pmtct_registrations.py
@@ -1,0 +1,42 @@
+from django.core.management.base import BaseCommand
+
+from registrations.models import Registration
+from registrations.tasks import validate_subscribe
+
+
+class Command(BaseCommand):
+    help = ("Find and fixes all PMTCT registrations that aren't validated"
+            "because of the edd date not being populated")
+
+    def handle(self, *args, **kwargs):
+
+        registrations = Registration.objects.filter(
+            validated=False,
+            reg_type__in=("pmtct_prebirth", "pmtct_postbirth")).iterator()
+
+        updates = 0
+
+        for registration in registrations:
+
+            related_regs = Registration.objects.filter(
+                    validated=True,
+                    registrant_id=registration.registrant_id
+                ).exclude(reg_type__in=("pmtct_prebirth", "pmtct_postbirth"))
+
+            for related_reg in related_regs:
+
+                if related_reg.data.get("edd"):
+                    del registration.data["invalid_fields"]
+                    registration.data["edd"] = related_reg.data["edd"]
+                    registration.save()
+
+                    validate_subscribe.apply_async(
+                        kwargs={"registration_id": str(registration.id)})
+
+                    updates += 1
+                    break
+
+        self.log("%s registrations fixed and validated." % (updates))
+
+    def log(self, log):
+        self.stdout.write('%s\n' % (log,))

--- a/registrations/management/commands/fix_pmtct_registrations.py
+++ b/registrations/management/commands/fix_pmtct_registrations.py
@@ -24,16 +24,17 @@ class Command(BaseCommand):
                 ).exclude(reg_type__in=("pmtct_prebirth", "pmtct_postbirth")).\
                 order_by('-created_at')
 
-            updated = False
-            for related_reg in related_regs:
-                for field in ['edd', 'language', 'mom_dob', 'operator_id']:
+            resubmit = True
+            for field in set(('edd', 'language', 'mom_dob', 'operator_id')).\
+                    difference(registration.data.keys()):
 
-                    if (related_reg.data.get(field) and
-                            not registration.data.get(field)):
-                        registration.data[field] = related_reg.data[field]
-                        updated = True
+                related_reg = related_regs.filter(data__has_key=field).first()
+                if related_reg:
+                    registration.data[field] = related_reg.data[field]
+                else:
+                    resubmit = False
 
-            if updated:
+            if resubmit:
                 registration.data.pop("invalid_fields", None)
                 registration.save()
 

--- a/registrations/management/commands/fix_pmtct_registrations.py
+++ b/registrations/management/commands/fix_pmtct_registrations.py
@@ -21,7 +21,8 @@ class Command(BaseCommand):
             related_regs = Registration.objects.filter(
                     validated=True,
                     registrant_id=registration.registrant_id
-                ).exclude(reg_type__in=("pmtct_prebirth", "pmtct_postbirth"))
+                ).exclude(reg_type__in=("pmtct_prebirth", "pmtct_postbirth")).\
+                order_by('-created_at')
 
             for related_reg in related_regs:
 

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -2647,7 +2647,12 @@ class TestFixPmtctRegistrationsCommand(AuthenticatedAPITestCase):
         data = {
             "reg_type": "momconnect_prebirth",
             "registrant_id": "mother01-63e2-4acc-9b94-26663b9bc267",
-            "data": {"edd": "2017-08-01"},
+            "data": {
+                "edd": "2017-08-01",
+                "mom_dob": "1982-08-01",
+                "language": "eng_ZA",
+                "operator_id": "operator-123456",
+            },
             "source": self.make_source_normaluser(),
             "validated": True
         }
@@ -2660,7 +2665,6 @@ class TestFixPmtctRegistrationsCommand(AuthenticatedAPITestCase):
             "reg_type": "pmtct_prebirth",
             "registrant_id": "mother01-63e2-4acc-9b94-26663b9bc267",
             "data": {
-                "operator_id": "mother01-63e2-4acc-9b94-26663b9bc267",
                 "mom_dob": "1987-04-24",
                 "invalid_fields": ["Estimated Due Date missing"],
                 "language": "eng_ZA"

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -2652,6 +2652,7 @@ class TestFixPmtctRegistrationsCommand(AuthenticatedAPITestCase):
                 "mom_dob": "1982-08-01",
                 "language": "eng_ZA",
                 "operator_id": "operator-123456",
+                "test": "test"
             },
             "source": self.make_source_normaluser(),
             "validated": True


### PR DESCRIPTION
Since the migration the new PMTCT registrations have been failing to validate, this is because the `edd` field was not populated.

This commands looks for a related subscription of a different type that is validated to get the `edd` date. It will then resubmit it for validation.