### PR TITLE
Change encdate to create date of item

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -571,8 +571,8 @@ class BasePushOptoutToJembi(object):
     def get_today(self):
         return datetime.datetime.today()
 
-    def get_timestamp(self):
-        return self.get_today().strftime("%Y%m%d%H%M%S")
+    def get_timestamp(self, change):
+        return change.created_at.strftime("%Y%m%d%H%M%S")
 
     def get_optout_reason(self, reason):
         """
@@ -643,7 +643,7 @@ class PushMomconnectOptoutToJembi(BasePushOptoutToJembi, Task):
         identity = is_client.get_identity(change.registrant_id) or {}
         address = self.get_identity_address(identity)
         return {
-            'encdate': self.get_timestamp(),
+            'encdate': self.get_timestamp(change),
             'mha': 1,
             'swt': 1,
             'cmsisdn': address,
@@ -666,7 +666,7 @@ class PushPMTCTOptoutToJembi(PushMomconnectOptoutToJembi, Task):
         identity = is_client.get_identity(change.registrant_id) or {}
         address = self.get_identity_address(identity)
         return {
-            'encdate': self.get_timestamp(),
+            'encdate': self.get_timestamp(change),
             'mha': 1,
             'swt': 1,
             'cmsisdn': address,
@@ -703,7 +703,7 @@ class PushMomconnectBabyLossToJembi(BasePushOptoutToJembi, Task):
         identity = is_client.get_identity(change.registrant_id) or {}
         address = self.get_identity_address(identity)
         return {
-            'encdate': self.get_timestamp(),
+            'encdate': self.get_timestamp(change),
             'mha': 1,
             'swt': 1,
             'cmsisdn': address,
@@ -739,7 +739,7 @@ class PushMomconnectBabySwitchToJembi(BasePushOptoutToJembi, Task):
         identity = is_client.get_identity(change.registrant_id) or {}
         address = self.get_identity_address(identity)
         return {
-            'encdate': self.get_timestamp(),
+            'encdate': self.get_timestamp(change),
             'mha': 1,
             'swt': 1,
             'cmsisdn': address,
@@ -787,7 +787,7 @@ class PushNurseconnectOptoutToJembi(BasePushOptoutToJembi, Task):
                 'Cannot find registration for change {}'.format(change.pk))
             return
         return {
-            'encdate': self.get_timestamp(),
+            'encdate': self.get_timestamp(change),
             'mha': 1,
             'swt': 1,
             'type': 8,

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import responses
-import mock
 try:
     from StringIO import StringIO
 except ImportError:
@@ -1156,9 +1155,7 @@ class TestChangeValidation(AuthenticatedAPITestCase):
 class TestChangeActions(AuthenticatedAPITestCase):
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectBabySwitchToJembi.get_today')
-    def test_baby_switch_momconnect_pmtct_nurseconnect_subs(self,
-                                                            mock_getdate):
+    def test_baby_switch_momconnect_pmtct_nurseconnect_subs(self):
         # Pretest
         self.assertEqual(Registration.objects.all().count(), 0)
         # Setup
@@ -1214,9 +1211,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
         # . this is a general patch - `responses` doesn't check the data
         utils_tests.mock_patch_identity("mother01-63e2-4acc-9b94-26663b9bc267")
 
-        # mock jembi sent date
-        mock_getdate.return_value = datetime.date(2016, 1, 1)
-
         # Execute
         result = validate_implement.apply_async(args=[change.id])
 
@@ -1232,15 +1226,14 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
             'cmsisdn': '+27821112222',
             'dmsisdn': '+27821112222',
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'type': 11,
         })
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectBabySwitchToJembi.get_today')
-    def test_baby_switch_momconnect_only_sub(self, mock_getdate):
+    def test_baby_switch_momconnect_only_sub(self):
         # Pretest
         self.assertEqual(Registration.objects.all().count(), 0)
         # Setup
@@ -1286,9 +1279,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
         # . this is a general patch - `responses` doesn't check the data
         utils_tests.mock_patch_identity("mother01-63e2-4acc-9b94-26663b9bc267")
 
-        # mock jembi sent date
-        mock_getdate.return_value = datetime.date(2016, 1, 1)
-
         # Execute
         result = validate_implement.apply_async(args=[change.id])
 
@@ -1304,15 +1294,14 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
             'cmsisdn': '+27821112222',
             'dmsisdn': '+27821112222',
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'type': 11,
         })
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectBabyLossToJembi.get_today')
-    def test_pmtct_loss_switch(self, mock_getdate):
+    def test_pmtct_loss_switch(self):
         # Setup
         # make registrations
         self.make_registration_momconnect_prebirth()
@@ -1359,9 +1348,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 },
             })
 
-        # mock jembi sent date
-        mock_getdate.return_value = datetime.date(2016, 1, 1)
-
         # Execute
         result = validate_implement.apply_async(args=[change.id])
 
@@ -1377,15 +1363,14 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
             'cmsisdn': '+27821112222',
             'dmsisdn': '+27821112222',
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'type': 5,
         })
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectOptoutToJembi.get_today')
-    def test_pmtct_loss_optout(self, mock_getdate):
+    def test_pmtct_loss_optout(self):
         # Setup
         # make registration
         self.make_registration_pmtct_prebirth()
@@ -1424,9 +1409,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 },
             })
 
-        # mock jembi sent date
-        mock_getdate.return_value = datetime.date(2016, 1, 1)
-
         # Execute
         result = validate_implement.apply_async(args=[change.id])
 
@@ -1444,7 +1426,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
             'cmsisdn': '+27821112222',
             'dmsisdn': '+27821112222',
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'optoutreason': 2,
@@ -1452,8 +1434,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         })
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectOptoutToJembi.get_today')
-    def test_pmtct_loss_optout_management_command(self, mock_getdate):
+    def test_pmtct_loss_optout_management_command(self):
         # Setup
         # make registration
         self.make_registration_pmtct_prebirth()
@@ -1479,9 +1460,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 },
             })
 
-        # mock jembi sent date
-        mock_getdate.return_value = datetime.date(2016, 1, 1)
-
         def format_timestamp(ts):
             return ts.strftime('%Y-%m-%d %H:%M:%S')
 
@@ -1501,7 +1479,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
             'cmsisdn': '+27821112222',
             'dmsisdn': '+27821112222',
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'optoutreason': 2,
@@ -1509,8 +1487,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         })
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectOptoutToJembi.get_today')
-    def test_pmtct_nonloss_optout(self, mock_getdate):
+    def test_pmtct_nonloss_optout(self):
         # Setup
         # make registration
         self.make_registration_pmtct_prebirth()
@@ -1550,9 +1527,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 },
             })
 
-        # mock jembi sent date
-        mock_getdate.return_value = datetime.date(2016, 1, 1)
-
         # Execute
         result = validate_implement.apply_async(args=[change.id])
 
@@ -1570,7 +1544,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
             'cmsisdn': '+27821112222',
             'dmsisdn': '+27821112222',
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'optoutreason': 5,
@@ -1637,8 +1611,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(len(responses.calls), 0)
 
     @responses.activate
-    @mock.patch('changes.tasks.PushNurseconnectOptoutToJembi.get_today')
-    def test_nurse_optout(self, mock_timestamp):
+    def test_nurse_optout(self):
         # Setup
         # make registration
         self.make_registration_nurseconnect()
@@ -1667,9 +1640,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
             "subscriptionid-nurseconnect-00000000"
         ])
 
-        # mock jembi sending timestamp
-        mock_timestamp.return_value = datetime.date(2016, 1, 1)
-
         # Execute
         result = validate_implement.apply_async(args=[change.id])
 
@@ -1683,7 +1653,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
 
         # Check Jembi send
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'type': 8,
@@ -1697,8 +1667,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         })
 
     @responses.activate
-    @mock.patch('changes.tasks.PushNurseconnectOptoutToJembi.get_today')
-    def test_nurse_optout_through_management_command(self, mock_timestamp):
+    def test_nurse_optout_through_management_command(self):
         # Setup
         # make registration
         self.make_registration_nurseconnect()
@@ -1716,9 +1685,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
         }
         change = Change.objects.create(**change_data)
 
-        # mock jembi sending timestamp
-        mock_timestamp.return_value = datetime.date(2016, 1, 1)
-
         def format_timestamp(ts):
             return ts.strftime('%Y-%m-%d %H:%M:%S')
 
@@ -1734,7 +1700,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
 
         # Check Jembi send
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'type': 8,
@@ -1748,8 +1714,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         })
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectBabyLossToJembi.get_today')
-    def test_momconnect_loss_switch_has_active(self, mock_today):
+    def test_momconnect_loss_switch_has_active(self):
         # Setup
         # make registrations
         self.make_registration_momconnect_prebirth()
@@ -1796,9 +1761,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 },
             })
 
-        # mock datetime
-        mock_today.return_value = datetime.date(2016, 1, 1)
-
         # Execute
         result = validate_implement.apply_async(args=[change.id])
 
@@ -1816,7 +1778,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
 
         # Check Jembi POST
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'cmsisdn': '+27111111111',
@@ -1858,8 +1820,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectBabyLossToJembi.get_today')
-    def test_momconnect_babyloss_via_management_task(self, mock_today):
+    def test_momconnect_babyloss_via_management_task(self):
         # Setup
         # make registration
         self.make_registration_momconnect_prebirth()
@@ -1886,9 +1847,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 },
             })
 
-        # mock datetime
-        mock_today.return_value = datetime.date(2016, 1, 1)
-
         def format_timestamp(ts):
             return ts.strftime('%Y-%m-%d %H:%M:%S')
 
@@ -1907,7 +1865,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
 
         # Check Jembi POST
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'cmsisdn': '+27111111111',
@@ -1921,8 +1879,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         ]))
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectBabySwitchToJembi.get_today')
-    def test_momconnect_babyswitch_via_management_task(self, mock_today):
+    def test_momconnect_babyswitch_via_management_task(self):
         # Setup
         # make registration
         self.make_registration_momconnect_prebirth()
@@ -1947,9 +1904,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 },
             })
 
-        # mock datetime
-        mock_today.return_value = datetime.date(2016, 1, 1)
-
         def format_timestamp(ts):
             return ts.strftime('%Y-%m-%d %H:%M:%S')
 
@@ -1968,7 +1922,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
 
         # Check Jembi POST
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'cmsisdn': '+27111111111',
@@ -1982,8 +1936,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         ]))
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectOptoutToJembi.get_today')
-    def test_momconnect_loss_optout(self, mock_today):
+    def test_momconnect_loss_optout(self):
         # Setup
         # make registration
         self.make_registration_momconnect_prebirth()
@@ -2023,9 +1976,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 },
             })
 
-        # mock datetime
-        mock_today.return_value = datetime.date(2016, 1, 1)
-
         # Execute
         result = validate_implement.apply_async(args=[change.id])
 
@@ -2039,7 +1989,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
 
         # Check Jembi POST
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'cmsisdn': '+27111111111',
@@ -2049,8 +1999,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         })
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectOptoutToJembi.get_today')
-    def test_momconnect_loss_optout_via_management_task(self, mock_today):
+    def test_momconnect_loss_optout_via_management_task(self):
         # Setup
         # make registration
         self.make_registration_momconnect_prebirth()
@@ -2077,9 +2026,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 },
             })
 
-        # mock datetime
-        mock_today.return_value = datetime.date(2016, 1, 1)
-
         def format_timestamp(ts):
             return ts.strftime('%Y-%m-%d %H:%M:%S')
 
@@ -2098,7 +2044,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
 
         # Check Jembi POST
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'cmsisdn': '+27111111111',
@@ -2113,8 +2059,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         ]))
 
     @responses.activate
-    @mock.patch('changes.tasks.PushMomconnectOptoutToJembi.get_today')
-    def test_momconnect_nonloss_optout(self, mock_today):
+    def test_momconnect_nonloss_optout(self):
         # Setup
         # make registration
         self.make_registration_momconnect_prebirth()
@@ -2146,9 +2091,6 @@ class TestChangeActions(AuthenticatedAPITestCase):
             "subscriptionid-pmtct-prebirth-000000"
         ])
 
-        # mock datetime
-        mock_today.return_value = datetime.date(2016, 1, 1)
-
         # mock identity lookup
         utils_tests.mock_get_identity_by_id(
             "mother01-63e2-4acc-9b94-26663b9bc267", {
@@ -2170,7 +2112,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
 
         # Check Jembi POST
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
-            'encdate': '20160101000000',
+            'encdate': change.created_at.strftime("%Y%m%d%H%M%S"),
             'mha': 1,
             'swt': 1,
             'cmsisdn': '+27111111111',

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -427,8 +427,8 @@ class BasePushRegistrationToJembi(object):
     def get_today(self):
         return datetime.today()
 
-    def get_timestamp(self):
-        return self.get_today().strftime("%Y%m%d%H%M%S")
+    def get_timestamp(self, registration):
+        return registration.created_at.strftime("%Y%m%d%H%M%S")
 
     @staticmethod
     def get_jembi_task_for_registration(registration):
@@ -559,7 +559,8 @@ class PushRegistrationToJembi(BasePushRegistrationToJembi, Task):
             "type": self.get_subscription_type(authority),
             "lang": self.transform_language_code(
                 registration.data['language']),
-            "encdate": registration.data.get('encdate', self.get_timestamp()),
+            "encdate": registration.data.get('encdate',
+                                             self.get_timestamp(registration)),
             "faccode": registration.data.get('faccode'),
             "dob": (self.get_dob(
                 datetime.strptime(registration.data['mom_dob'], '%Y-%m-%d'))
@@ -636,7 +637,7 @@ class PushNurseRegistrationToJembi(BasePushRegistrationToJembi, Task):
                     else None),
             "persal": self.get_persal(identity),
             "sanc": self.get_sanc(identity),
-            "encdate": self.get_timestamp(),
+            "encdate": self.get_timestamp(registration),
         }
 
         return json_template

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -18,7 +18,6 @@ from django.conf import settings
 from django.test import TestCase, override_settings
 from django.db.models.signals import post_save
 from django.utils import timezone
-from mock import patch
 from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.authtoken.models import Token
@@ -2163,8 +2162,7 @@ class TestSubscriptionRequestCreation(AuthenticatedAPITestCase):
 class TestRegistrationCreation(AuthenticatedAPITestCase):
 
     @responses.activate
-    @patch('registrations.tasks.PushRegistrationToJembi.get_today')
-    def test_registration_process_pmtct_good(self, mock_date):
+    def test_registration_process_pmtct_good(self):
         """ Test a full registration process with good data """
         # Setup
         registrant_uuid = "mother01-63e2-4acc-9b94-26663b9bc267"
@@ -2199,7 +2197,6 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         utils_tests.mock_get_schedule(schedule_id)
         utils_tests.mock_get_identity_by_id(registrant_uuid)
         utils_tests.mock_patch_identity(registrant_uuid)
-        mock_date.return_value = datetime.date(2016, 1, 1)
 
         # Execute
         registration = Registration.objects.create(**registration_data)
@@ -2218,7 +2215,7 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
             'dmsisdn': '+27821113333',
             'faccode': '123456',
             'id': '8108015001051^^^ZAF^NI',
-            'encdate': '20160101000000',
+            'encdate': registration.created_at.strftime("%Y%m%d%H%M%S"),
             'type': 9,
             'swt': 1,
             'mha': 1,
@@ -2244,8 +2241,7 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         post_save.disconnect(psh_validate_subscribe, sender=Registration)
 
     @responses.activate
-    @patch('registrations.tasks.PushRegistrationToJembi.get_today')
-    def test_registration_process_pmtct_minimal_data(self, mock_date):
+    def test_registration_process_pmtct_minimal_data(self):
         """ Test a full registration process with good data """
         # Setup
         registrant_uuid = "mother01-63e2-4acc-9b94-26663b9bc267"
@@ -2281,7 +2277,6 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
             'default_addr_type': 'msisdn',
         })
         utils_tests.mock_patch_identity(registrant_uuid)
-        mock_date.return_value = datetime.date(2016, 1, 1)
 
         # Execute
         registration = Registration.objects.create(**registration_data)
@@ -2300,7 +2295,7 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
             'dmsisdn': '+8108015001051',
             'faccode': '123456',
             'id': '8108015001051^^^ZAF^TEL',
-            'encdate': '20160101000000',
+            'encdate': registration.created_at.strftime("%Y%m%d%H%M%S"),
             'type': 9,
             'swt': 1,
             'mha': 1,


### PR DESCRIPTION
One of the fields that is being sent to Jembi is `encdate`, this requires the timestamp of when the event happened, because we sometimes send through items late, it is better to use the item create date instead of current timestamp.