### PR TITLE
Endpoint to create an Optout change when messages have repeatedly failed

### DIFF
--- a/changes/tests.py
+++ b/changes/tests.py
@@ -502,7 +502,8 @@ class TestChangeAPI(AuthenticatedAPITestCase):
         # Setup
         self.make_source_normaluser()
         post_data = {
-            "identity_id": "846877e6-afaa-43de-acb1-09f61ad4de99"
+            "data": {
+                "identity_id": "846877e6-afaa-43de-acb1-09f61ad4de99"}
         }
         # Execute
         response = self.normalclient.post('/api/v1/change/inactive/',

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -498,6 +498,25 @@ class TestChangeAPI(AuthenticatedAPITestCase):
         self.assertEqual(d.validated, False)  # Should ignore True post_data
         self.assertEqual(d.data, {"test_key1": "test_value1"})
 
+    def test_optout_inactive_identity(self):
+        # Setup
+        self.make_source_normaluser()
+        post_data = {
+            "identity_id": "846877e6-afaa-43de-acb1-09f61ad4de99"
+        }
+        # Execute
+        response = self.normalclient.post('/api/v1/change/inactive/',
+                                          json.dumps(post_data),
+                                          content_type='application/json')
+        # Check
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        d = Change.objects.last()
+        self.assertEqual(d.source.name, 'test_source_normaluser')
+        self.assertEqual(d.action, 'momconnect_nonloss_optout')
+        self.assertEqual(d.validated, False)
+        self.assertEqual(d.data, {"reason": "sms_failure"})
+
 
 class TestChangeListAPI(AuthenticatedAPITestCase):
 

--- a/changes/urls.py
+++ b/changes/urls.py
@@ -11,5 +11,6 @@ router.register(r'changes', views.ChangeGetViewSet)
 # Additionally, we include login URLs for the browseable API.
 urlpatterns = [
     url(r'^api/v1/', include(router.urls)),
+    url(r'^api/v1/change/inactive/$', views.OptOutInactiveIdentity.as_view()),
     url(r'^api/v1/change/', views.ChangePost.as_view()),
 ]

--- a/changes/views.py
+++ b/changes/views.py
@@ -58,9 +58,13 @@ class OptOutInactiveIdentity(APIView):
     permission_classes = (IsAuthenticated,)
 
     def post(self, request, *args, **kwargs):
-        data = request.data
+        try:
+            # The hooks send the request data as {"hook":{}, "data":{}}
+            data = request.data['data']
+        except KeyError:
+            raise ValidationError('"data" must be supplied')
         identity_id = data.get('identity_id', None)
-        if identity_id is None:
+        if identity_id is None or identity_id == "":
             raise ValidationError(
                 '"identity_id" must be supplied')
         source = Source.objects.get(user=request.user)


### PR DESCRIPTION
Adds an endpoint to optout identities that have failed to receive messages.
The endpoint expects the identity to optout and creates an optout change with the reason of `sms_failure`