### PR TITLE
Add old language to change object when changing identity language

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -382,12 +382,18 @@ class ValidateImplement(Task):
 
         self.l.info("Fetching identity {}".format(change.registrant_id))
         identity = is_client.get_identity(change.registrant_id)
+
+        self.l.info("Updating Change object")
+        change.data['old_language'] = identity['details'].get('lang_code')
+        change.save()
+
         self.l.info(
             "Changing language for identity {}".format(change.registrant_id))
         identity['details']['lang_code'] = language
         is_client.update_identity(identity['id'], {
             'details': identity['details']
             })
+
         return "Completed Momconnect language change"
 
     # Validation checks

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -2307,3 +2307,34 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(json.loads(postbirth_update.request.body), {
             'lang': "xho_ZA"
         })
+
+    @responses.activate
+    def test_momconnect_change_language_old_language(self):
+        """
+        The action should update the change data with the previous language
+        that was set on the identity before the change.
+        """
+        registrant_id = "mother01-63e2-4acc-9b94-26663b9bc267"
+        utils_tests.mock_get_identity_by_id(
+            registrant_id, {
+                'lang_code': "eng_ZA",
+                'foo': "bar",
+            })
+        utils_tests.mock_patch_identity(registrant_id)
+
+        mock_get_active_subscriptions_none(registrant_id)
+
+        change = Change.objects.create(
+            registrant_id=registrant_id,
+            action="momconnect_change_language",
+            data={
+                'language': "xho_ZA"
+            },
+            source=self.make_source_normaluser()
+        )
+
+        validate_implement(change.id)
+        change.refresh_from_db()
+        self.assertTrue(change.validated)
+        self.assertEqual(change.data['language'], 'xho_ZA')
+        self.assertEqual(change.data['old_language'], 'eng_ZA')


### PR DESCRIPTION
When changing the language of an identity, we should keep the old language somewhere so that we have a record of it.