### PR TITLE
Remove personal information from registrations

### DIFF
--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -82,6 +82,24 @@ def mock_patch_identity(identity_id):
     )
 
 
+def mock_create_identity(identity_id='identity-uuid', details={}):
+    identity = {
+        "id": identity_id,
+        "version": 1,
+        "details": details,
+        "communicate_through": None,
+        "operator": None,
+        "created_at": "2016-03-31T09:28:29.506591Z",
+        "created_by": None,
+        "updated_at": "2016-08-17T09:44:31.812532Z",
+        "updated_by": 1
+    }
+    responses.add(
+        responses.POST,
+        'http://is/api/v1/identities/', json=identity, status=200,
+        content_type='application_json')
+
+
 def mock_get_messageset_by_shortname(short_name):
     messageset_id = {
         "pmtct_prebirth.patient.1": 11,

--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -1,6 +1,9 @@
 import responses
 import json
-import urllib
+try:
+    from urllib import urlencode
+except ImportError:
+    from urllib.parse import urlencode
 
 
 # Mocks used in testing
@@ -49,7 +52,7 @@ def mock_get_identity_by_msisdn(msisdn, identity_id='identity-uuid', num=1):
 
     responses.add(
         responses.GET,
-        'http://is/api/v1/identities/search/?%s' % urllib.urlencode({
+        'http://is/api/v1/identities/search/?%s' % urlencode({
             'details__addresses__msisdn': msisdn}),
         json=response, status=200, content_type='application/json',
         match_querystring=True)

--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -1,5 +1,6 @@
 import responses
 import json
+import urllib
 
 
 # Mocks used in testing
@@ -29,6 +30,29 @@ def mock_get_identity_by_id(identity_id, details={}):
         json=identity,
         status=200, content_type='application/json'
     )
+
+
+def mock_get_identity_by_msisdn(msisdn, identity_id='identity-uuid', num=1):
+    """
+    Mocks the request to the identity store to get identities by msisdn.
+    """
+    response = {'results': [{
+        "id": identity_id,
+        "version": 1,
+        "details": {'addresses': {'msisdn': {msisdn: {}}}},
+        "communicate_through": None,
+        "operator": None,
+        "created_at": "2016-03-31T09:28:29.506591Z",
+        "created_by": None,
+        "updated_at": "2016-08-17T09:44:31.812532Z",
+    }] * num}
+
+    responses.add(
+        responses.GET,
+        'http://is/api/v1/identities/search/?%s' % urllib.urlencode({
+            'details__addresses__msisdn': msisdn}),
+        json=response, status=200, content_type='application/json',
+        match_querystring=True)
 
 
 def mock_patch_identity(identity_id):

--- a/registrations/admin.py
+++ b/registrations/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from .models import Source, Registration, SubscriptionRequest
+from .tasks import remove_personally_identifiable_fields
 
 
 class RegistrationAdmin(admin.ModelAdmin):
@@ -8,6 +9,11 @@ class RegistrationAdmin(admin.ModelAdmin):
         "created_at", "updated_at", "created_by", "updated_by"]
     list_filter = ["source", "validated", "created_at"]
     search_fields = ["registrant_id", "data"]
+    actions = ['remove_personal_information']
+
+    def remove_personal_information(modeladmin, request, queryset):
+        for q in queryset.iterator():
+            remove_personally_identifiable_fields.delay(str(q.pk))
 
 
 class SubscriptionRequestAdmin(admin.ModelAdmin):

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -402,9 +402,14 @@ def remove_personally_identifiable_fields(registration_id):
     fields = set((
         'id_type', 'mom_dob', 'passport_no', 'passport_origin', 'sa_id_no',
         'language', 'consent')).intersection(registration.data.keys())
-    identity = is_client.get_identity(registration.registrant_id)
-    for field in fields:
-        identity['details'][field] = registration.data.pop(field)
+    if fields:
+        identity = is_client.get_identity(registration.registrant_id)
+
+        for field in fields:
+            identity['details'][field] = registration.data.pop(field)
+
+        is_client.update_identity(
+            identity['id'], {'details': identity['details']})
 
     msisdn_fields = set((
         'msisdn_device', 'msisdn_registrant')
@@ -425,8 +430,6 @@ def remove_personally_identifiable_fields(registration_id):
         field = field.replace('msisdn', 'uuid')
         registration.data[field] = field_identity['id']
 
-    is_client.update_identity(
-        identity['id'], {'details': identity['details']})
     registration.save()
 
 

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -2323,8 +2323,6 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         Registration.objects.create(**registration_data)
 
         # check jembi registration
-        for r in responses.calls:
-            print r.request.url
         jembi_call = responses.calls[12]  # jembi should be the thirteenth one
         self.assertEqual(
             json.loads(jembi_call.request.body)['faccode'], '123456')
@@ -2380,8 +2378,6 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         self.assertEqual(len(responses.calls), 8)
 
         # check jembi registration
-        for r in responses.calls:
-            print r.request.url
         jembi_call = responses.calls[5]  # jembi should be the sixth one
         self.assertEqual(json.loads(jembi_call.request.body), {
             'lang': 'en',
@@ -2577,8 +2573,6 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         self.assertFalse(registration.validated)
         registration.save()
 
-        for r in responses.calls:
-            print r.response.text
         jembi_call = responses.calls[2]  # jembi should be the third one
         self.assertEqual(json.loads(jembi_call.response.text), {
             "result": "jembi-is-ok"

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -2167,6 +2167,11 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         """ Test a full registration process with good data """
         # Setup
         registrant_uuid = "mother01-63e2-4acc-9b94-26663b9bc267"
+        utils_tests.mock_get_identity_by_id(
+            "mother01-63e2-4acc-9b94-26663b9bc267")
+        utils_tests.mock_patch_identity(
+            "mother01-63e2-4acc-9b94-26663b9bc267")
+        utils_tests.mock_get_identity_by_msisdn('+27821113333')
         # . reactivate post-save hook
         post_save.connect(psh_validate_subscribe, sender=Registration)
 
@@ -2205,10 +2210,11 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         # Check
         # . check number of calls made:
         #   messageset, schedule, identity, patch identity, jembi registration
-        self.assertEqual(len(responses.calls), 5)
+        #   identity, reverse identity, reverse identity, patch identity
+        self.assertEqual(len(responses.calls), 9)
 
         # check jembi registration
-        jembi_call = responses.calls[-1]  # jembi should be the last one
+        jembi_call = responses.calls[4]  # jembi should be the fifth one
         self.assertEqual(json.loads(jembi_call.request.body), {
             'lang': 'en',
             'dob': '19990127',
@@ -2247,6 +2253,11 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         """ Test a full registration process with good data """
         # Setup
         registrant_uuid = "mother01-63e2-4acc-9b94-26663b9bc267"
+        utils_tests.mock_get_identity_by_id(
+            "mother01-63e2-4acc-9b94-26663b9bc267")
+        utils_tests.mock_patch_identity(
+            "mother01-63e2-4acc-9b94-26663b9bc267")
+        utils_tests.mock_get_identity_by_msisdn('+27821113333')
         # . reactivate post-save hook
         post_save.connect(psh_validate_subscribe, sender=Registration)
 
@@ -2312,7 +2323,9 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         Registration.objects.create(**registration_data)
 
         # check jembi registration
-        jembi_call = responses.calls[-1]  # jembi should be the last one
+        for r in responses.calls:
+            print r.request.url
+        jembi_call = responses.calls[12]  # jembi should be the thirteenth one
         self.assertEqual(
             json.loads(jembi_call.request.body)['faccode'], '123456')
 
@@ -2363,10 +2376,13 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         # Check
         # . check number of calls made:
         #   messageset, schedule, identity, patch identity, jembi registration
-        self.assertEqual(len(responses.calls), 6)
+        #   get identity, patch identity
+        self.assertEqual(len(responses.calls), 8)
 
         # check jembi registration
-        jembi_call = responses.calls[-1]  # jembi should be the last one
+        for r in responses.calls:
+            print r.request.url
+        jembi_call = responses.calls[5]  # jembi should be the sixth one
         self.assertEqual(json.loads(jembi_call.request.body), {
             'lang': 'en',
             'dob': '19990127',
@@ -2405,6 +2421,11 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         """ Test a full registration process with good data """
         # Setup
         # registrant_uuid = "mother01-63e2-4acc-9b94-26663b9bc267"
+        utils_tests.mock_get_identity_by_id(
+            "mother01-63e2-4acc-9b94-26663b9bc267")
+        utils_tests.mock_patch_identity(
+            "mother01-63e2-4acc-9b94-26663b9bc267")
+        utils_tests.mock_get_identity_by_msisdn('+27821113333')
         # . reactivate post-save hook
         post_save.connect(psh_validate_subscribe, sender=Registration)
 
@@ -2447,8 +2468,9 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
 
         # Check
         # . check number of calls made:
-        #   message set, schedule, service rating, jembi registration
-        self.assertEqual(len(responses.calls), 3)
+        #   message set, schedule, jembi registration, id_store mother,
+        #   id_store mother_reverse, id_store registrant_rever, id_store patch
+        self.assertEqual(len(responses.calls), 7)
 
         # . check registration validated
         registration.refresh_from_db()
@@ -2524,6 +2546,8 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
                 "cmsisdn": "+27111111111",
                 "lang": "en",
             })
+        utils_tests.mock_get_identity_by_msisdn('+27000000000')
+        utils_tests.mock_get_identity_by_msisdn('+27111111111')
 
         # Setup
         source = Source.objects.create(
@@ -2553,7 +2577,9 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         self.assertFalse(registration.validated)
         registration.save()
 
-        jembi_call = responses.calls[-1]  # jembi should be the last one
+        for r in responses.calls:
+            print r.response.text
+        jembi_call = responses.calls[2]  # jembi should be the third one
         self.assertEqual(json.loads(jembi_call.response.text), {
             "result": "jembi-is-ok"
         })
@@ -2581,6 +2607,7 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
                 "cmsisdn": "+27710967611",
                 "lang": "en",
             })
+        utils_tests.mock_get_identity_by_msisdn('+27710967611')
 
         # Setup
         source = Source.objects.create(
@@ -2609,7 +2636,7 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         self.assertFalse(registration.validated)
         registration.save()
 
-        jembi_call = responses.calls[-1]  # jembi should be the last one
+        jembi_call = responses.calls[2]  # jembi should be the third one
         self.assertEqual(json.loads(jembi_call.response.text), {
             "result": "jembi-is-ok"
         })


### PR DESCRIPTION
Currently, there is personal information stored in registrations, so when we "forget" a user in the identity store, wiping the information from there doesn't clear all the information we have on them.

Instead, once we are done with this information, we should make sure it's stored on the identity, in case we need it later, and then we should remove it from the registration object in the database.