### PR TITLE
Add personally identifiable information back for change management commands

### DIFF
--- a/changes/management/commands/jembi_submit_babyloss.py
+++ b/changes/management/commands/jembi_submit_babyloss.py
@@ -1,6 +1,11 @@
+from celery import chain
 from uuid import UUID
 from django.core.management import BaseCommand, CommandError
 from django.utils.dateparse import parse_datetime
+
+from changes.tasks import (
+    restore_personally_identifiable_fields,
+    remove_personally_identifiable_fields)
 
 
 class Command(BaseCommand):
@@ -54,6 +59,11 @@ class Command(BaseCommand):
             'Submitting %s changes.' % (changes.count(),))
         for change in changes.filter(action__in=(
                 'pmtct_loss_switch', 'momconnect_loss_switch')):
-            push_momconnect_babyloss_to_jembi.delay(str(change.pk))
+            restore_personally_identifiable_fields(change)
+            change.save()
+            push_task = push_momconnect_babyloss_to_jembi.si(str(change.pk))
+            remove_info_task = remove_personally_identifiable_fields.si(
+                str(change.pk))
+            chain(push_task, remove_info_task).delay()
             self.stdout.write(str(change.pk))
         self.stdout.write('Done.')

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -19,7 +19,9 @@ from rest_hooks.models import model_saved
 from ndoh_hub import utils, utils_tests
 from .models import Change
 from .signals import psh_validate_implement
-from .tasks import validate_implement, remove_personally_identifiable_fields
+from .tasks import (
+    validate_implement, remove_personally_identifiable_fields,
+    restore_personally_identifiable_fields)
 from registrations.models import Source, Registration, SubscriptionRequest
 from registrations.signals import (psh_validate_subscribe,
                                    psh_fire_created_metric)
@@ -1929,6 +1931,9 @@ class TestChangeActions(AuthenticatedAPITestCase):
         }
         change = Change.objects.create(**change_data)
 
+        utils_tests.mock_get_identity_by_id(
+            'nurse001-63e2-4acc-9b94-26663b9bc267')
+
         def format_timestamp(ts):
             return ts.strftime('%Y-%m-%d %H:%M:%S')
 
@@ -2105,7 +2110,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
             stdout=stdout)
 
         # Check
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(responses.calls), 3)
 
         # Check Jembi POST
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
@@ -2162,7 +2167,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
             stdout=stdout)
 
         # Check
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(responses.calls), 3)
 
         # Check Jembi POST
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
@@ -2284,7 +2289,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
             stdout=stdout)
 
         # Check
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(responses.calls), 3)
 
         # Check Jembi POST
         self.assertEqual(json.loads(responses.calls[-1].request.body), {
@@ -2928,4 +2933,81 @@ class TestRemovePersonallyIdentifiableInformation(AuthenticatedAPITestCase):
         change.refresh_from_db()
         self.assertEqual(change.data, {
             'uuid_device': 'device-uuid',
+        })
+
+
+class TestRestorePersonallyIdentifiableInformation(AuthenticatedAPITestCase):
+    @responses.activate
+    def test_restores_personal_information_fields(self):
+        """
+        Any personal information fields that exist on the identity, but
+        not on the change object, should be placed on the change object.
+        """
+        change = Change.objects.create(
+            registrant_id='mother-uuid',
+            action='baby_switch',
+            source=self.make_source_normaluser(),
+            validated=True,
+            data={
+                'id_type': 'passport',
+            })
+
+        utils_tests.mock_get_identity_by_id('mother-uuid', {
+            'id_type': 'sa_id',
+            'dob': '1990-01-01',
+            'passport_no': '1234',
+            'passport_origin': 'na',
+            'sa_id_no': '4321',
+            'persal_no': '111',
+            'sanc_no': '222',
+        })
+
+        restore_personally_identifiable_fields(change)
+        self.assertEqual(change.data, {
+            'id_type': 'passport',
+            'dob': '1990-01-01',
+            'passport_no': '1234',
+            'passport_origin': 'na',
+            'sa_id_no': '4321',
+            'persal_no': '111',
+            'sanc_no': '222',
+        })
+
+    @responses.activate
+    def test_restores_msisdn_fields(self):
+        """
+        If any of the uuid fields exist on the change object, then an msisdn
+        lookup should be done for those msisdns, and the msisdn should be
+        placed on the change object.
+        """
+        change = Change.objects.create(
+            registrant_id='mother-uuid',
+            action='baby_switch',
+            source=self.make_source_normaluser(),
+            validated=True,
+            data={
+                'uuid_device': 'device-uuid',
+                'uuid_new': 'new-uuid',
+                'uuid_old': 'old-uuid',
+            })
+
+        utils_tests.mock_get_identity_by_id('mother-uuid')
+        utils_tests.mock_get_identity_by_id('device-uuid', {
+            'addresses': {'msisdn': {'+1111': {}}},
+        })
+        utils_tests.mock_get_identity_by_id('new-uuid', {
+            'addresses': {'msisdn': {
+                '+2222': {'default': True},
+                '+3333': {},
+            }},
+        })
+        utils_tests.mock_get_identity_by_id('old-uuid')
+
+        restore_personally_identifiable_fields(change)
+        self.assertEqual(change.data, {
+            'uuid_device': 'device-uuid',
+            'uuid_new': 'new-uuid',
+            'uuid_old': 'old-uuid',
+            'msisdn_device': '+1111',
+            'msisdn_new': '+2222',
         })

--- a/ndoh_hub/utils.py
+++ b/ndoh_hub/utils.py
@@ -6,13 +6,42 @@ import datetime
 from celery.task import Task
 from django.conf import settings
 from go_http.metrics import MetricsApiClient
-from seed_services_client.stage_based_messaging import StageBasedMessagingApiClient  # noqa
+from seed_services_client.stage_based_messaging import (
+    StageBasedMessagingApiClient)
+from seed_services_client.identity_store import IdentityStoreApiClient
 
 
 sbm_client = StageBasedMessagingApiClient(
     api_url=settings.STAGE_BASED_MESSAGING_URL,
     auth_token=settings.STAGE_BASED_MESSAGING_TOKEN
 )
+
+is_client = IdentityStoreApiClient(
+    api_url=settings.IDENTITY_STORE_URL,
+    auth_token=settings.IDENTITY_STORE_TOKEN
+)
+
+
+def get_identity_msisdn(registrant_id):
+    """
+    Given an identity UUID, returns the msisdn for the identity. Takes into
+    account default addresses, opted out addresses, and missing identities
+    or addresses. Returns None when it cannot find an MSISDN address.
+    """
+    identity = is_client.get_identity(registrant_id)
+    if not identity:
+        return
+
+    msisdns = \
+        identity['details'].get('addresses', {}).get('msisdn', {})
+
+    identity_msisdn = None
+    for msisdn, details in msisdns.items():
+        if 'default' in details and details['default']:
+            return msisdn
+        if not ('optedout' in details and details['optedout']):
+            identity_msisdn = msisdn
+    return identity_msisdn
 
 
 def is_valid_uuid(id):

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -458,29 +458,12 @@ def add_personally_identifiable_fields(registration):
         'uuid_device', 'uuid_registrant')
         ).intersection(registration.data.keys())
     for field in uuid_fields:
-        msisdn = get_identity_msisdn(registration.data[field])
+        msisdn = utils.get_identity_msisdn(registration.data[field])
         if msisdn:
             field = field.replace('uuid', 'msisdn')
             registration.data[field] = msisdn
 
     return registration
-
-
-def get_identity_msisdn(registrant_id):
-    identity = is_client.get_identity(registrant_id)
-    if not identity:
-        return
-
-    msisdns = \
-        identity['details'].get('addresses', {}).get('msisdn', {})
-
-    identity_msisdn = None
-    for msisdn, details in msisdns.items():
-        if 'default' in details and details['default']:
-            return msisdn
-        if not ('optedout' in details and details['optedout']):
-            identity_msisdn = msisdn
-    return identity_msisdn
 
 
 class BasePushRegistrationToJembi(object):
@@ -623,7 +606,7 @@ class PushRegistrationToJembi(BasePushRegistrationToJembi, Task):
 
         id_msisdn = None
         if not registration.data.get('msisdn_registrant'):
-            id_msisdn = get_identity_msisdn(registration.registrant_id)
+            id_msisdn = utils.get_identity_msisdn(registration.registrant_id)
 
         json_template = {
             "mha": registration.data.get('mha', 1),


### PR DESCRIPTION
For the management commands, some of them rely on the information that was present in the change objects before the change to remove this information.

We want to add this information back, do whatever we need to with it, and then remove it again at the end.