### PR TITLE
Remove code to change jembi optout type based on messageset

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -92,15 +92,8 @@ class ValidateImplement(Task):
             )["results"])
 
         self.l.info("Deactivating active nurseconnect subscriptions")
-        last_messageset_id = None
         for active_sub in active_subs:
             sbm_client.update_subscription(active_sub["id"], {"active": False})
-            last_messageset_id = active_sub["messageset"]
-        # Record name of the last messageset deactivated to send to jembi
-        [change.data['last_messageset']] = [
-            ms['short_name'] for ms in nc_messagesets
-            if ms['id'] == last_messageset_id]
-        change.save()
 
     def deactivate_pmtct(self, change):
         """ Deactivates any pmtct subscriptions
@@ -1018,10 +1011,6 @@ class PushNurseconnectOptoutToJembi(BasePushOptoutToJembi, Task):
     name = "ndoh_hub.changes.tasks.push_nurseconnect_optout_to_jembi"
     l = get_task_logger(__name__)
     URL = "%s/nc/optout" % settings.JEMBI_BASE_URL
-    messageset_optout_types = {
-        "nurseconnect.hw_full.1": 8,
-        "nurseconnect_childm.hw_full.1": 11
-    }
 
     def get_nurse_id(
             self, id_type, id_no=None, passport_origin=None, mom_msisdn=None):
@@ -1055,8 +1044,7 @@ class PushNurseconnectOptoutToJembi(BasePushOptoutToJembi, Task):
             'encdate': self.get_timestamp(change),
             'mha': 1,
             'swt': 1,
-            'type': self.messageset_optout_types.get(
-                change.data.get("last_messageset", None), 8),
+            'type': 8,
             "cmsisdn": registration.data['msisdn_registrant'],
             "dmsisdn": registration.data['msisdn_device'],
             'rmsisdn': None,


### PR DESCRIPTION
After further discussion with Jembi we've decided not to send them a different type since the new message set is essentially a continuation of the program.