### PR TITLE
Use lang_code for identity language

### DIFF
--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -407,6 +407,10 @@ def remove_personally_identifiable_fields(registration_id):
         identity = is_client.get_identity(registration.registrant_id)
 
         for field in fields:
+            #  Language is stored as 'lang_code' in the Identity Store
+            if field == 'language':
+                identity['details']['lang_code'] = registration.data.pop(field)
+                continue
             identity['details'][field] = registration.data.pop(field)
 
         is_client.update_identity(
@@ -449,10 +453,13 @@ def add_personally_identifiable_fields(registration):
 
     fields = set((
         'id_type', 'mom_dob', 'passport_no', 'passport_origin', 'sa_id_no',
-        'language', 'consent'))\
+        'lang_code', 'consent'))\
         .intersection(identity['details'].keys())\
         .difference(registration.data.keys())
     for field in fields:
+        if field == 'lang_code':
+            registration.data['language'] = identity['details'][field]
+            continue
         registration.data[field] = identity['details'][field]
 
     uuid_fields = set((

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -3554,8 +3554,7 @@ class TestRemovePersonallyIdentifiableFieldsTask(AuthenticatedAPITestCase):
             'passport_origin': "na",
             'passport_no': '1234',
             'sa_id_no': '4321',
-            'lang_code': 'afr_ZA',
-            'language': 'eng_ZA',
+            'lang_code': 'eng_ZA',
             'consent': True,
             'foo': "bar"
         }})
@@ -3670,7 +3669,7 @@ class TestAddPersonallyIdentifiableFields(AuthenticatedAPITestCase):
             'passport_origin': "na",
             'passport_no': '1234',
             'sa_id_no': '4321',
-            'language': 'eng_ZA',
+            'lang_code': 'eng_ZA',
             'consent': True,
             'foo': "baz",
         })
@@ -3728,6 +3727,7 @@ class TestAddPersonallyIdentifiableFields(AuthenticatedAPITestCase):
             'uuid_registrant': 'uuid-registrant',
             'msisdn_device': 'msisdn-device',
             'msisdn_registrant': 'msisdn-registrant',
+            'language': 'afr_ZA',
         })
 
     @responses.activate
@@ -3751,5 +3751,5 @@ class TestAddPersonallyIdentifiableFields(AuthenticatedAPITestCase):
         registration = add_personally_identifiable_fields(registration)
 
         self.assertEqual(registration.data, {
-            'uuid_device': 'uuid-device',
+            'uuid_device': 'uuid-device', 'language': 'afr_ZA'
         })


### PR DESCRIPTION
The language in the Identity store for NdoH is stored under the key `lang_code` not `language`