### PR TITLE
Additional subscription request for POPI messages

### DIFF
--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -129,7 +129,8 @@ def mock_get_messageset_by_shortname(short_name):
         "loss_miscarriage.patient.1": 51,
         "loss_stillbirth.patient.1": 52,
         "loss_babyloss.patient.1": 53,
-        "nurseconnect.hw_full.1": 61
+        "nurseconnect.hw_full.1": 61,
+        "popi.hw_full.1": 71,
     }[short_name]
 
     default_schedule = {
@@ -151,7 +152,8 @@ def mock_get_messageset_by_shortname(short_name):
         "loss_miscarriage.patient.1": 151,
         "loss_stillbirth.patient.1": 152,
         "loss_babyloss.patient.1": 153,
-        "nurseconnect.hw_full.1": 161
+        "nurseconnect.hw_full.1": 161,
+        "popi.hw_full.1": 171,
     }[short_name]
 
     responses.add(
@@ -193,7 +195,8 @@ def mock_get_messageset(messageset_id):
         51: "loss_miscarriage.patient.1",
         52: "loss_stillbirth.patient.1",
         53: "loss_babyloss.patient.1",
-        61: "nurseconnect.hw_full.1"
+        61: "nurseconnect.hw_full.1",
+        71: "popi.hw_full.1",
     }[messageset_id]
 
     default_schedule = {
@@ -215,7 +218,8 @@ def mock_get_messageset(messageset_id):
         "loss_miscarriage.patient.1": 151,
         "loss_stillbirth.patient.1": 152,
         "loss_babyloss.patient.1": 153,
-        "nurseconnect.hw_full.1": 161
+        "nurseconnect.hw_full.1": 161,
+        "popi.hw_full.1": 171,
     }[short_name]
 
     responses.add(

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -269,7 +269,7 @@ class ValidateSubscribe(Task):
         """
         Creates a new subscription request for the POPI message set. This
         message set tells the user how to access the POPI required services.
-        This sould only be sent for Clinic or CHW registrations.
+        This should only be sent for Clinic or CHW registrations.
         """
         if ('prebirth' not in registration.reg_type or
            registration.source.authority not in ['hw_partial', 'hw_full']):

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -2473,8 +2473,9 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
 
         # Check
         # . check number of calls made:
-        #   message set, schedule, jembi registration, id_store mother,
-        #   id_store mother_reverse, id_store registrant_rever, id_store patch
+        #   message set, schedule, popi message set, jembi registration,
+        #   id_store mother, id_store mother_reverse,
+        #   id_store registrant_rever, id_store patch
         self.assertEqual(len(responses.calls), 8)
 
         # . check registration validated

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -2265,6 +2265,7 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         utils_tests.mock_patch_identity(
             "mother01-63e2-4acc-9b94-26663b9bc267")
         utils_tests.mock_get_identity_by_msisdn('+27821113333')
+        utils_tests.mock_get_messageset_by_shortname('popi.hw_full.1')
         # . reactivate post-save hook
         post_save.connect(psh_validate_subscribe, sender=Registration)
 
@@ -2330,7 +2331,7 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         Registration.objects.create(**registration_data)
 
         # check jembi registration
-        jembi_call = responses.calls[12]  # jembi should be the thirteenth one
+        jembi_call = responses.calls[13]  # jembi should be the fourteenth one
         self.assertEqual(
             json.loads(jembi_call.request.body)['faccode'], '123456')
 
@@ -2429,6 +2430,7 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         utils_tests.mock_patch_identity(
             "mother01-63e2-4acc-9b94-26663b9bc267")
         utils_tests.mock_get_identity_by_msisdn('+27821113333')
+        utils_tests.mock_get_messageset_by_shortname('popi.hw_full.1')
         # . reactivate post-save hook
         post_save.connect(psh_validate_subscribe, sender=Registration)
 
@@ -2473,19 +2475,27 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         # . check number of calls made:
         #   message set, schedule, jembi registration, id_store mother,
         #   id_store mother_reverse, id_store registrant_rever, id_store patch
-        self.assertEqual(len(responses.calls), 7)
+        self.assertEqual(len(responses.calls), 8)
 
         # . check registration validated
         registration.refresh_from_db()
         self.assertEqual(registration.validated, True)
 
         # . check subscriptionrequest object
-        sr = SubscriptionRequest.objects.last()
+        sr = SubscriptionRequest.objects.filter(messageset=21).first()
         self.assertEqual(sr.identity, "mother01-63e2-4acc-9b94-26663b9bc267")
         self.assertEqual(sr.messageset, 21)
         self.assertEqual(sr.next_sequence_number, 37)  # ((23 - 4) * 2) - 1
         self.assertEqual(sr.lang, "eng_ZA")
         self.assertEqual(sr.schedule, 121)
+
+        # check popi subscription request object
+        sr = SubscriptionRequest.objects.filter(messageset=71).first()
+        self.assertEqual(sr.identity, "mother01-63e2-4acc-9b94-26663b9bc267")
+        self.assertEqual(sr.messageset, 71)
+        self.assertEqual(sr.next_sequence_number, 1)
+        self.assertEqual(sr.lang, "eng_ZA")
+        self.assertEqual(sr.schedule, 171)
 
         # Teardown
         post_save.disconnect(psh_validate_subscribe, sender=Registration)


### PR DESCRIPTION
What we want to do, is the day after a mother has registered for the service, they should get an SMS detailing how to connect to the new POPI USSD line.

The way this PR proposes to implement it, is to create a new subscription for the mother, to a special message set that contains just the POPI message/s that we want to send, that detail how to access the new POPI line.