### PR TITLE
Management command for revalidating invalid registrations

### DIFF
--- a/ndoh_hub/utils.py
+++ b/ndoh_hub/utils.py
@@ -61,7 +61,7 @@ def is_valid_date(date):
 def is_valid_edd(date):
     """
     Checks given Estimated Due Date is in the future but not more than
-    9 months always
+    9 months away
     """
     if is_valid_date(date):
         edd = datetime.datetime.strptime(date, "%Y-%m-%d")

--- a/ndoh_hub/utils.py
+++ b/ndoh_hub/utils.py
@@ -58,6 +58,19 @@ def is_valid_date(date):
         return False
 
 
+def is_valid_edd(date):
+    """
+    Checks given Estimated Due Date is in the future but not more than
+    9 months always
+    """
+    if is_valid_date(date):
+        edd = datetime.datetime.strptime(date, "%Y-%m-%d")
+        if (edd > get_today() and
+                edd < get_today() + datetime.timedelta(weeks=43)):
+            return True
+    return False
+
+
 def is_valid_lang(lang):
     return lang in [
         "zul_ZA",  # isiZulu

--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -300,3 +300,24 @@ def mock_jembi_json_api_call(url, ok_response="ok", err_response="err",
         return (201, {}, json.dumps({"result": ok_response}))
 
     responses.add_callback(responses.POST, url, callback=request_callback)
+
+
+def mock_get_active_subscriptions(identity, count=0):
+    subscriptions = []
+    for i in range(count):
+        subscriptions.insert(i, {
+                "id": "sub-3401-63e2-4acc-9b94-26663b9bc267",
+                "identity": identity,
+                "messageset": 1,
+                "next_sequence_number": 1,
+                "lang": "eng_ZA",
+                "active": True
+        })
+
+    responses.add(
+        responses.GET,
+        'http://sbm.org/api/v1/subscriptions/?active=True&identity=%s' %
+        identity,
+        json={"results": subscriptions}, match_querystring=True,
+        status=200, content_type='application/json',
+    )

--- a/registrations/management/commands/revalidate_registrations.py
+++ b/registrations/management/commands/revalidate_registrations.py
@@ -1,0 +1,102 @@
+from os import environ
+
+from django.core.management.base import BaseCommand, CommandError
+
+from registrations.models import Registration
+from registrations.tasks import (
+    add_personally_identifiable_fields, validate_subscribe)
+
+from seed_services_client import StageBasedMessagingApiClient
+
+from ._utils import validate_and_return_url
+
+
+class Command(BaseCommand):
+    help = ("Validates all invalid Registrations that failed with the given "
+            "error. This should also lead to the creation of a  Subscription "
+            "in the SMB service")
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--blind', action='store_false', default=True,
+            dest='check_subscription',
+            help=('Do not check with the stage based messaging API whether'
+                  'or not a subscription for the identity already exists.'
+                  'NOT RECOMMENDED AT ALL'))
+        parser.add_argument(
+            '--sbm-url', dest='sbm_url', type=validate_and_return_url,
+            default=environ.get('STAGE_BASED_MESSAGING_URL'),
+            help=('The Stage Based Messaging Service to verify '
+                  'subscriptions for.'))
+        parser.add_argument(
+            '--sbm-token', dest='sbm_token',
+            default=environ.get('STAGE_BASED_MESSAGING_TOKEN'),
+            help=('The Authorization token for the SBM Service')
+        )
+        parser.add_argument(
+            '--invalid-field', dest='invalid_field', default=None,
+            help=("Field that failed to validate when registration was "
+                  "created. Must match 'invalid_field' in registration data")
+        )
+        parser.add_argument(
+            '--batch-size', dest='batch_size', type=int, default=None,
+            help=("The number of registrations to process. This allows batch "
+                  "processing.")
+        )
+
+    def handle(self, *args, **kwargs):
+        sbm_url = kwargs['sbm_url']
+        sbm_token = kwargs['sbm_token']
+        check_subscription = kwargs['check_subscription']
+        invalid_field = kwargs['invalid_field']
+        batch_size = kwargs['batch_size']
+
+        if check_subscription:
+            if not sbm_url:
+                raise CommandError(
+                    'Please make sure either the STAGE_BASED_MESSAGING_URL '
+                    'environment variable or --sbm-url is set.')
+
+            if not sbm_token:
+                raise CommandError(
+                    'Please make sure either the STAGE_BASED_MESSAGING_TOKEN '
+                    'environment variable or --sbm-token is set.')
+            client = StageBasedMessagingApiClient(sbm_token, sbm_url)
+
+        registrations = Registration.objects.filter(
+            validated=False, data__invalid_fields__contains=[invalid_field])
+
+        if batch_size is not None:
+            registrations = registrations[:batch_size]
+
+        count = 0
+        for reg in registrations.iterator():
+            self.log("Validating registration %s" % reg.id)
+            if check_subscription and self.count_subscriptions(client, reg):
+                self.log(('Identity %s already has subscription. Skipping.')
+                         % (reg.registrant_id))
+                continue
+            """
+            validate_subscribe() checks all data for the registration is valid
+            and creates the Subscription Request
+            """
+            if not reg.data.get('msisdn_device', ''):
+                add_personally_identifiable_fields(reg)
+            reg.save()
+            result = validate_subscribe(registration_id=str(reg.id))
+            if not result:
+                reg.refresh_from_db()
+                "Registration %s still invalid" % reg.id
+            else:
+                count += 1
+        self.log("Successfully revalidated %s registrations" % count)
+
+    def log(self, log):
+        self.stdout.write('%s\n' % (log,))
+
+    def count_subscriptions(self, sbm_client, registration):
+        subscriptions = sbm_client.get_subscriptions({
+            'identity': registration.registrant_id, 'active': True
+        })
+        count = len(subscriptions['results'])
+        return count

--- a/registrations/management/commands/revalidate_registrations.py
+++ b/registrations/management/commands/revalidate_registrations.py
@@ -14,7 +14,7 @@ from ._utils import validate_and_return_url
 class Command(BaseCommand):
     help = ("Validates all invalid Registrations that failed with the given "
             "error. This should also lead to the creation of a  Subscription "
-            "in the SMB service")
+            "in the SBM service")
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -76,10 +76,9 @@ class Command(BaseCommand):
                 self.log(('Identity %s already has subscription. Skipping.')
                          % (reg.registrant_id))
                 continue
-            """
-            validate_subscribe() checks all data for the registration is valid
-            and creates the Subscription Request
-            """
+
+            # validate_subscribe() checks all data for the registration is
+            # valid and creates the Subscription Request
             if not reg.data.get('msisdn_device', ''):
                 add_personally_identifiable_fields(reg)
             reg.save()

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -76,7 +76,7 @@ class ValidateSubscribe(Task):
     def check_edd(self, data_fields, registration):
         if "edd" not in data_fields:
             return ["Estimated Due Date missing"]
-        elif not utils.is_valid_date(registration.data["edd"]):
+        elif not utils.is_valid_edd(registration.data["edd"]):
             return ["Estimated Due Date invalid"]
         else:
             return []

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -11,6 +11,7 @@ try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse
+import mock
 
 from django.contrib.auth.models import User
 from django.core.management import call_command
@@ -61,6 +62,20 @@ class TestUtils(TestCase):
         self.assertEqual(utils.is_valid_date(good_date), True)
         self.assertEqual(utils.is_valid_date(invalid_date), False)
         self.assertEqual(utils.is_valid_date(bad_date), False)
+
+    def test_is_valid_edd(self):
+        # Setup
+        good_edd = "2016-03-01"
+        past_edd = "2015-12-31"
+        far_future_edd = "2017-01-01"
+        not_date = "1234"
+        # Execute
+        # Check
+        with mock.patch('ndoh_hub.utils.get_today', override_get_today):
+            self.assertEqual(utils.is_valid_edd(good_edd), True)
+            self.assertEqual(utils.is_valid_edd(past_edd), False)
+            self.assertEqual(utils.is_valid_edd(far_future_edd), False)
+            self.assertEqual(utils.is_valid_edd(not_date), False)
 
     def test_is_valid_uuid(self):
         # Setup

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -1345,12 +1345,13 @@ class TestRegistrationValidation(AuthenticatedAPITestCase):
                 "operator_id": "mother01-63e2-4acc-9b94-26663b9bc267",
                 "language": "eng_ZA",
                 "mom_dob": "1999-01-27",
-                "edd": "2016-11-30",
+                "edd": "2016-08-30",
             },
         }
         registration = Registration.objects.create(**registration_data)
-        # Execute
-        v = validate_subscribe.validate(registration)
+        with mock.patch('ndoh_hub.utils.get_today', override_get_today):
+            # Execute
+            v = validate_subscribe.validate(registration)
         # Check
         self.assertEqual(v, True)
 
@@ -2818,7 +2819,8 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
 class TestFixPmtctRegistrationsCommand(AuthenticatedAPITestCase):
 
     @responses.activate
-    def test_fix_pmtct_registrations(self):
+    @mock.patch('ndoh_hub.utils.get_today', return_value=override_get_today())
+    def test_fix_pmtct_registrations(self, mock_today):
         schedule_id = utils_tests.mock_get_messageset_by_shortname(
             'pmtct_prebirth.patient.1')
         utils_tests.mock_get_schedule(schedule_id)
@@ -2836,7 +2838,7 @@ class TestFixPmtctRegistrationsCommand(AuthenticatedAPITestCase):
             "reg_type": "momconnect_prebirth",
             "registrant_id": "mother01-63e2-4acc-9b94-26663b9bc267",
             "data": {
-                "edd": "2017-08-01",
+                "edd": "2016-08-01",
                 "mom_dob": "1982-08-01",
                 "language": "eng_ZA",
                 "operator_id": "operator-123456",
@@ -2872,7 +2874,7 @@ class TestFixPmtctRegistrationsCommand(AuthenticatedAPITestCase):
 
         self.assertEqual(stdout.getvalue().strip(),
                          '2 registrations fixed and validated.')
-        self.assertEqual(check_registration.data.get("edd"), "2017-08-01")
+        self.assertEqual(check_registration.data.get("edd"), "2016-08-01")
         self.assertEqual(check_registration.validated, True)
 
 


### PR DESCRIPTION
A number of bugs in the system have led to some valid registrations being marked as invalid. These have been fixed so we should try to re-validate the registrations affected. This adds a management command to do that.