### PR TITLE
Set swt based on Junebug channel type when reporting on inbound messages

### DIFF
--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -231,3 +231,7 @@ JEMBI_BASE_URL = os.environ.get('JEMBI_BASE_URL',
                                 'http://jembi/ws/rest/v1')
 JEMBI_USERNAME = os.environ.get('JEMBI_USERNAME', 'test')
 JEMBI_PASSWORD = os.environ.get('JEMBI_PASSWORD', 'test')
+JUNEBUG_BASE_URL = os.environ.get('JUNEBUG_BASE_URL', 'http://junebug')
+JUNEBUG_USERNAME = os.environ.get('JUNEBUG_USERNAME', 'REPLACEME')
+JUNEBUG_PASSWORD = os.environ.get('JUNEBUG_PASSWORD', 'REPLACEME')
+WHATSAPP_CHANNEL_TYPE = os.environ.get('WHATSAPP_CHANNEL_TYPE', 'wassup')

--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -5,8 +5,6 @@ try:
 except ImportError:
     from urllib.parse import urlencode
 
-from django.conf import settings
-
 
 # Mocks used in testing
 def mock_get_identity_by_id(identity_id, details={}):
@@ -322,7 +320,7 @@ def mock_junebug_channel_call(url, channel_type):
     data = {
         "status": 200,
         "code": "OK",
-        "description": "channel created",
+        "description": "channel found",
         "result": {
             "status": {},
             "mo_url": "http://www.example.com/first_channel/mo",

--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -5,6 +5,8 @@ try:
 except ImportError:
     from urllib.parse import urlencode
 
+from django.conf import settings
+
 
 # Mocks used in testing
 def mock_get_identity_by_id(identity_id, details={}):
@@ -314,6 +316,26 @@ def mock_jembi_json_api_call(url, ok_response="ok", err_response="err",
         return (201, {}, json.dumps({"result": ok_response}))
 
     responses.add_callback(responses.POST, url, callback=request_callback)
+
+
+def mock_junebug_channel_call(url, channel_type):
+    data = {
+        "status": 200,
+        "code": "OK",
+        "description": "channel created",
+        "result": {
+            "status": {},
+            "mo_url": "http://www.example.com/first_channel/mo",
+            "label": "My First Channel",
+            "type": channel_type,
+            "config": {"twisted_endpoint": "tcp:9001"}
+        }
+    }
+
+    responses.add(
+        responses.GET, url, json=data, status=200,
+        content_type='application/json',
+    )
 
 
 def mock_get_active_subscriptions(identity, count=0):

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -73,3 +73,4 @@ class JembiHelpdeskOutgoingSerializer(serializers.Serializer):
     label = serializers.CharField(allow_blank=True)
     inbound_created_on = serializers.DateTimeField()
     outbound_created_on = serializers.DateTimeField()
+    inbound_channel_id = serializers.CharField(required=False)

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -171,6 +171,9 @@ class JembiHelpdeskOutgoingView(APIView):
             return date.strftime("%Y%m%d%H%M%S")
 
         def get_software_type(channel_id):
+            """ Returns the swt value based on the type of the Junebug channel.
+                Defaults to sms type
+            """
             if not channel_id:
                 return 2
             result = requests.get(


### PR DESCRIPTION
In order to inform Jembi about messages from Whatsapp we need to know the type of the channel that the message came in on. This code retrieves this information from Junebug