### PR TITLE
New Jembi endpoint for NC helpdesk

### DIFF
--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -3485,7 +3485,7 @@ class TestJembiHelpdeskOutgoing(AuthenticatedAPITestCase):
 
     @responses.activate
     def test_send_outgoing_message_to_jembi_nurseconnect(self):
-        source = self.make_source_normaluser('nc_helpdesk')
+        source = self.make_source_normaluser('NURSE Helpdesk App')
         self.make_registration_for_jembi_helpdesk(source)
 
         utils_tests.mock_jembi_json_api_call(

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -444,9 +444,9 @@ class AuthenticatedAPITestCase(APITestCase):
         }
         return Source.objects.create(**data)
 
-    def make_source_normaluser(self):
+    def make_source_normaluser(self, name="test_source_normaluser"):
         data = {
-            "name": "test_source_normaluser",
+            "name": name,
             "authority": "patient",
             "user": User.objects.get(username='testnormaluser')
         }
@@ -3418,11 +3418,11 @@ class TestJembiHelpdeskOutgoing(AuthenticatedAPITestCase):
         self.outbound_created_on_date = datetime.datetime.strptime(
             "2016-01-02", "%Y-%m-%d")
 
-    def make_registration_for_jembi_helpdesk(self):
+    def make_registration_for_jembi_helpdesk(self, source=None):
         registration_data = {
             "reg_type": "momconnect_prebirth",
             "registrant_id": "mother01-63e2-4acc-9b94-26663b9bc267",
-            "source": self.make_source_normaluser(),
+            "source": source or self.make_source_normaluser(),
             "data": {
                 "operator_id": "operator-123456",
                 "msisdn_registrant": "+27821113333",
@@ -3444,6 +3444,52 @@ class TestJembiHelpdeskOutgoing(AuthenticatedAPITestCase):
 
         utils_tests.mock_jembi_json_api_call(
             url='http://jembi/ws/rest/v1/helpdesk',
+            ok_response="jembi-is-ok",
+            err_response="jembi-is-unhappy",
+            fields={})
+
+        utils_tests.mock_junebug_channel_call(
+            'http://junebug/jb/channels/6a5c691e-140c-48b0-9f39-a53d4951d7fa',
+            'sms')
+
+        user_request = {
+            "to": "+27123456789",
+            "content": "this is a sample response",
+            "reply_to": "this is a sample user message",
+            "inbound_created_on": self.inbound_created_on_date,
+            "outbound_created_on": self.outbound_created_on_date,
+            "user_id": 'mother01-63e2-4acc-9b94-26663b9bc267',
+            "helpdesk_operator_id": 1234,
+            "label": 'Complaint',
+            "inbound_channel_id": "6a5c691e-140c-48b0-9f39-a53d4951d7fa"}
+        # Execute
+        response = self.normalclient.post(
+            '/api/v1/jembi/helpdesk/outgoing/', user_request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(responses.calls), 2)
+        request_json = json.loads(responses.calls[1].request.body)
+
+        self.assertEqual(request_json['dmsisdn'], '+27123456789')
+        self.assertEqual(request_json['cmsisdn'], '+27123456789')
+        self.assertEqual(request_json['encdate'], '20160101000000')
+        self.assertEqual(request_json['repdate'], '20160102000000')
+        self.assertEqual(request_json['mha'], 1)
+        self.assertEqual(request_json['swt'], 2)
+        self.assertEqual(request_json['faccode'], '123456')
+        self.assertEqual(request_json['data'], {
+            'question': u'this is a sample user message',
+            'answer': u'this is a sample response'})
+        self.assertEqual(request_json['class'], 'Complaint')
+        self.assertEqual(request_json['type'], 7)
+        self.assertEqual(request_json['op'], "1234")
+
+    @responses.activate
+    def test_send_outgoing_message_to_jembi_nurseconnect(self):
+        source = self.make_source_normaluser('nc_helpdesk')
+        self.make_registration_for_jembi_helpdesk(source)
+
+        utils_tests.mock_jembi_json_api_call(
+            url='http://jembi/ws/rest/v1/nc/helpdesk',
             ok_response="jembi-is-ok",
             err_response="jembi-is-unhappy",
             fields={})
@@ -3527,6 +3573,8 @@ class TestJembiHelpdeskOutgoing(AuthenticatedAPITestCase):
 
     @responses.activate
     def test_send_outgoing_message_to_jembi_invalid_user_id(self):
+        self.make_source_normaluser()
+
         utils_tests.mock_jembi_json_api_call(
             url='http://jembi/ws/rest/v1/helpdesk',
             ok_response="jembi-is-ok",

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -204,7 +204,7 @@ class JembiHelpdeskOutgoingView(APIView):
             "repdate": jembi_format_date(
                 validated_data.get('outbound_created_on')),
             "mha": 1,
-            "swt": swt,  # 1 ussd, 2 sms
+            "swt": swt,  # 1 ussd, 2 sms, 4 whatsapp
             "cmsisdn": validated_data.get('to'),
             "dmsisdn": validated_data.get('to'),
             "faccode":
@@ -233,8 +233,15 @@ class JembiHelpdeskOutgoingView(APIView):
 
         post_data = self.build_jembi_helpdesk_json(serializer.validated_data)
         try:
+
+            source = Source.objects.get(user=self.request.user.id)
+
+            endpoint = 'helpdesk'
+            if source.name == 'nc_helpdesk':
+                endpoint = 'nc/helpdesk'
+
             result = requests.post(
-                '%s/helpdesk' % settings.JEMBI_BASE_URL,
+                '%s/%s' % (settings.JEMBI_BASE_URL, endpoint),
                 headers={'Content-Type': 'application/json'},
                 data=json.dumps(post_data),
                 auth=(settings.JEMBI_USERNAME, settings.JEMBI_PASSWORD),

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -237,7 +237,7 @@ class JembiHelpdeskOutgoingView(APIView):
             source = Source.objects.get(user=self.request.user.id)
 
             endpoint = 'helpdesk'
-            if source.name == 'nc_helpdesk':
+            if source.name == 'NURSE Helpdesk App':
                 endpoint = 'nc/helpdesk'
 
             result = requests.post(


### PR DESCRIPTION
New link for helpdesk outgoing messages on NC helpdesk:
`/ws/rest/v1/nc/helpdesk`

I use the source object linked to the authenticated user to determine which helpdesk the outgoing comes from.

Payload is the same as Momconnect.