### PR TITLE
Fix regex for switching WhatsApp to SMS

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -548,7 +548,7 @@ class ValidateImplement(Task):
                 # Change any WhatsApp subscriptions to SMS
                 sbm_client.update_subscription(sub['id'], {'active': False})
                 messageset = messagesets_rev[
-                    re.sub('^whatsapp^', '', short_name)]
+                    re.sub('^whatsapp_', '', short_name)]
                 SubscriptionRequest.objects.create(
                     identity=sub['identity'],
                     messageset=messageset,

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -3528,7 +3528,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
 
         [sub_req] = SubscriptionRequest.objects.all()
         self.assertEqual(sub_req.identity, registrant_id)
-        self.assertEqual(sub_req.messageset, 0)
+        self.assertEqual(sub_req.messageset, 1)
         self.assertEqual(sub_req.next_sequence_number, 7)
         self.assertEqual(sub_req.lang, 'eng')
         self.assertEqual(sub_req.schedule, 2)


### PR DESCRIPTION
The regex for this was incorrect, which resulted in a switch from whatsapp to SMS keeping the user on WhatsApp