### PR TITLE
Fix websocket event not being sent

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -40,9 +40,9 @@ class RegistrationSerializer(serializers.ModelSerializer):
         model = Registration
         read_only_fields = ('validated', 'created_by', 'updated_by',
                             'created_at', 'updated_at')
-        fields = ('id', 'reg_type', 'registrant_id', 'validated', 'data',
-                  'source', 'created_at', 'updated_at', 'created_by',
-                  'updated_by')
+        fields = ('id', 'external_id', 'reg_type', 'registrant_id',
+                  'validated', 'data', 'source', 'created_at', 'updated_at',
+                  'created_by', 'updated_by')
 
 
 class HookSerializer(serializers.ModelSerializer):

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -615,10 +615,6 @@ class ValidateSubscribeJembiAppRegistration(HTTPRetryMixin, ValidateSubscribe):
         url = registration.data.get('callback_url', None)
         token = registration.data.get('callback_auth_token', None)
 
-        if url is None:
-            # No webhook if no URL is specified
-            return
-
         headers = {}
         if token is not None:
             headers['Authorization'] = 'Token {}'.format(token)
@@ -627,9 +623,11 @@ class ValidateSubscribeJembiAppRegistration(HTTPRetryMixin, ValidateSubscribe):
             'type': 'registration.event',
             'data': registration.status,
         })
-        return http_request_with_retries.delay(
-            method='POST', url=url, headers=headers,
-            payload=registration.status)
+
+        if url is not None:
+            http_request_with_retries.delay(
+                method='POST', url=url, headers=headers,
+                payload=registration.status)
 
     def is_registered_on_whatsapp(self, address):
         """


### PR DESCRIPTION
Currently, if the URL is not specified, then the webhook function will return early, not sending the websocket message. This should be changed, so that the websocket status update gets sent whether or not a callback URL is specified