### PR TITLE
Standardize Jembi url format

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -2,6 +2,10 @@ import datetime
 import json
 import re
 import requests
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 
 from celery import chain
 from celery.task import Task
@@ -1027,7 +1031,7 @@ class PushMomconnectOptoutToJembi(BasePushOptoutToJembi, Task):
     """
     name = "ndoh_hub.changes.tasks.push_momconnect_optout_to_jembi"
     log = get_task_logger(__name__)
-    URL = "%s/optout" % settings.JEMBI_BASE_URL
+    URL = urljoin(settings.JEMBI_BASE_URL, 'optout')
 
     def build_jembi_json(self, change):
         identity = is_client.get_identity(change.registrant_id) or {}
@@ -1051,7 +1055,7 @@ class PushPMTCTOptoutToJembi(PushMomconnectOptoutToJembi, Task):
     Sends a PMTCT optout change to Jembi.
     """
     name = "ndoh_hub.changes.tasks.push_pmtct_optout_to_jembi"
-    URL = "%s/pmtctOptout" % settings.JEMBI_BASE_URL
+    URL = urljoin(settings.JEMBI_BASE_URL, 'pmtctOptout')
 
     def build_jembi_json(self, change):
         identity = is_client.get_identity(change.registrant_id) or {}
@@ -1076,7 +1080,7 @@ class PushMomconnectBabyLossToJembi(BasePushOptoutToJembi, Task):
     """
     name = "ndoh_hub.changes.tasks.push_momconnect_babyloss_to_jembi"
     log = get_task_logger(__name__)
-    URL = "%s/subscription" % settings.JEMBI_BASE_URL
+    URL = urljoin(settings.JEMBI_BASE_URL, 'subscription')
 
     def build_jembi_json(self, change):
         identity = is_client.get_identity(change.registrant_id) or {}
@@ -1100,7 +1104,7 @@ class PushMomconnectBabySwitchToJembi(BasePushOptoutToJembi, Task):
     """
     name = "ndoh_hub.changes.tasks.push_momconnect_babyswitch_to_jembi"
     log = get_task_logger(__name__)
-    URL = "%s/subscription" % settings.JEMBI_BASE_URL
+    URL = urljoin(settings.JEMBI_BASE_URL, 'subscription')
 
     def build_jembi_json(self, change):
         identity = is_client.get_identity(change.registrant_id) or {}
@@ -1124,7 +1128,7 @@ class PushNurseconnectOptoutToJembi(BasePushOptoutToJembi, Task):
     """
     name = "ndoh_hub.changes.tasks.push_nurseconnect_optout_to_jembi"
     log = get_task_logger(__name__)
-    URL = "%s/nc/optout" % settings.JEMBI_BASE_URL
+    URL = urljoin(settings.JEMBI_BASE_URL, 'nc/optout')
 
     def get_nurse_id(
             self, id_type, id_no=None, passport_origin=None, mom_msisdn=None):

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -297,7 +297,7 @@ SERVICE_RATING_URL = os.environ.get('SERVICE_RATING_URL',
 SERVICE_RATING_TOKEN = os.environ.get('SERVICE_RATING_TOKEN',
                                       'REPLACEME')
 JEMBI_BASE_URL = os.environ.get('JEMBI_BASE_URL',
-                                'http://jembi/ws/rest/v1')
+                                'http://jembi/ws/rest/v1/')
 JEMBI_USERNAME = os.environ.get('JEMBI_USERNAME', 'test')
 JEMBI_PASSWORD = os.environ.get('JEMBI_PASSWORD', 'test')
 JUNEBUG_BASE_URL = os.environ.get('JUNEBUG_BASE_URL', 'http://junebug')

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -888,7 +888,7 @@ class PushRegistrationToJembi(BasePushRegistrationToJembi, Task):
     """
     name = "ndoh_hub.registrations.tasks.push_registration_to_jembi"
     log = get_task_logger(__name__)
-    URL = "%s/subscription" % settings.JEMBI_BASE_URL
+    URL = urljoin(settings.JEMBI_BASE_URL, 'subscription')
 
     def get_subscription_type(self, authority):
         authority_map = {
@@ -983,7 +983,7 @@ class PushPmtctRegistrationToJembi(PushRegistrationToJembi, Task):
     """ Task to push PMTCT registration data to Jembi
     """
     name = "ndoh_hub.registrations.tasks.push_pmtct_registration_to_jembi"
-    URL = "%s/pmtctSubscription" % settings.JEMBI_BASE_URL
+    URL = urljoin(settings.JEMBI_BASE_URL, 'pmtctSubscription')
 
     def build_jembi_json(self, registration):
         json_template = super(PushPmtctRegistrationToJembi, self).\
@@ -1016,7 +1016,7 @@ push_pmtct_registration_to_jembi = PushPmtctRegistrationToJembi()
 class PushNurseRegistrationToJembi(BasePushRegistrationToJembi, Task):
     name = "ndoh_hub.registrations.tasks.push_nurse_registration_to_jembi"
     log = get_task_logger(__name__)
-    URL = "%s/nc/subscription" % settings.JEMBI_BASE_URL
+    URL = urljoin(settings.JEMBI_BASE_URL, 'nc/subscription')
 
     def get_persal(self, identity):
         details = identity['details']

--- a/registrations/test_tasks.py
+++ b/registrations/test_tasks.py
@@ -365,7 +365,7 @@ class ValidateSubscribeJembiAppRegistrationsTests(TestCase):
         """
         responses.add(
             responses.GET,
-            'http://jembi/ws/rest/facilityCheck?criteria=code%3A123456',
+            'http://jembi/ws/rest/v1/facilityCheck?criteria=code%3A123456',
             json={
                 "title": "FacilityCheck",
                 "headers": [
@@ -421,7 +421,7 @@ class ValidateSubscribeJembiAppRegistrationsTests(TestCase):
         """
         responses.add(
             responses.GET,
-            'http://jembi/ws/rest/facilityCheck?criteria=code%3A123456',
+            'http://jembi/ws/rest/v1/facilityCheck?criteria=code%3A123456',
             json={
                 "title": "FacilityCheck",
                 "headers": [],

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -3,6 +3,10 @@ import django_filters.rest_framework as filters
 import json
 import requests
 import logging
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 
 from django.conf import settings
 from django.contrib.auth.models import User, Group
@@ -250,7 +254,7 @@ class JembiHelpdeskOutgoingView(APIView):
                 post_data['type'] = 12  # NC Helpdesk
 
             result = requests.post(
-                '%s/%s' % (settings.JEMBI_BASE_URL, endpoint),
+                urljoin(settings.JEMBI_BASE_URL, endpoint),
                 headers={'Content-Type': 'application/json'},
                 data=json.dumps(post_data),
                 auth=(settings.JEMBI_USERNAME, settings.JEMBI_PASSWORD),


### PR DESCRIPTION
In some places we were using string concatenation and in some places we were using `urljoin`.

This make everything use `urljoin`.