### PR TITLE
Add view for receiving whatsapp events

### DIFF
--- a/changes/serializers.py
+++ b/changes/serializers.py
@@ -43,3 +43,18 @@ class AdminChangeSerializer(serializers.Serializer):
     language = serializers.CharField(required=False)
 
     validators = [OneFieldRequiredValidator(['messageset', 'language'])]
+
+
+class ReceiveWhatsAppEventSerializer(serializers.Serializer):
+
+    class HookSerializer(serializers.Serializer):
+        event = serializers.ChoiceField(['message.direct_outbound.status'])
+    hook = HookSerializer()
+
+    class EventSerializer(serializers.Serializer):
+        status = serializers.ChoiceField(['unsent'])
+
+        class MessageMetadata(serializers.Serializer):
+            junebug_message_id = serializers.UUIDField()
+        message_metadata = MessageMetadata()
+    data = EventSerializer()

--- a/changes/test_serializers.py
+++ b/changes/test_serializers.py
@@ -1,0 +1,105 @@
+from django.test import TestCase
+
+from changes.serializers import ReceiveWhatsAppEventSerializer
+
+
+class ReceiveWhatsAppEventSerializerTests(TestCase):
+    def test_valid(self):
+        serializer = ReceiveWhatsAppEventSerializer(data={
+            'hook': {
+                'event': 'message.direct_outbound.status',
+            },
+            'data': {
+                'id': 12345,
+                'message_uuid': '8773bd92-a28a-438d-942b-3b8aca3a216e',
+                'contact_uuid': 'f87e5256-f26d-4e96-97b4-ed5e4d462a33',
+                'group_uuid': None,
+                'message_metadata': {
+                    'wassup_reply': {},
+                    'junebug_reply_to': None,
+                    'junebug_message_id': '41c377a47b064eba9abee5a1ea827b3d',
+                },
+                'uuid': '8ec6b95a-f43e-4000-8f4d-bf3e359bb3e',
+                'status': 'unsent',
+                'description': None,
+                'timestamp': '2018-04-19T09:36:38Z',
+                'created_at': '2018-04-19T09:36:38.842036Z',
+                'updated_at': '2018-04-19T09:36:38.842054Z',
+                'message': 12346,
+                'contact': 12347,
+            },
+        })
+
+        self.assertTrue(serializer.is_valid())
+
+    def test_invalid_incorrect_event(self):
+        """
+        If the event is not message.direct_outbound.status, then the serializer
+        should be invalid
+        """
+        serializer = ReceiveWhatsAppEventSerializer(data={
+            'hook': {
+                'event': 'message.direct_outbound',
+            },
+            'data': {
+                'message_metadata': {
+                    'junebug_message_id': '41c377a47b064eba9abee5a1ea827b3d',
+                },
+                'status': 'unsent',
+            },
+        })
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors, {
+            'hook': {
+                'event': ['"message.direct_outbound" is not a valid choice.'],
+            },
+        })
+
+    def test_invalid_incorrect_status(self):
+        """
+        If the status is not unsent, then the serializer should be invalid
+        """
+        serializer = ReceiveWhatsAppEventSerializer(data={
+            'hook': {
+                'event': 'message.direct_outbound.status',
+            },
+            'data': {
+                'message_metadata': {
+                    'junebug_message_id': '41c377a47b064eba9abee5a1ea827b3d',
+                },
+                'status': 'sent',
+            },
+        })
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors, {
+            'data': {
+                'status': ['"sent" is not a valid choice.'],
+            },
+        })
+
+    def test_invalid_incorrect_junebug_message_id(self):
+        """
+        junebug_message_id must be present, and must be a valid UUID.
+        """
+        serializer = ReceiveWhatsAppEventSerializer(data={
+            'hook': {
+                'event': 'message.direct_outbound.status',
+            },
+            'data': {
+                'message_metadata': {
+                    'junebug_message_id': 'bad-uuid',
+                },
+                'status': 'unsent',
+            },
+        })
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors, {
+            'data': {
+                'message_metadata': {
+                    'junebug_message_id': ['"bad-uuid" is not a valid UUID.'],
+                },
+            },
+        })

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -1,0 +1,52 @@
+from django.contrib.auth.models import User
+from django.db.models.signals import post_save
+from django.test import TestCase
+import responses
+
+from registrations.models import Source
+from changes.models import Change
+from changes.signals import psh_validate_implement
+from changes.tasks import process_whatsapp_unsent_event
+
+
+class ProcessWhatsAppUnsentEventTaskTests(TestCase):
+    def setUp(self):
+        post_save.disconnect(
+            receiver=psh_validate_implement, sender=Change)
+
+    def tearDown(self):
+        post_save.connect(
+            receiver=psh_validate_implement, sender=Change)
+
+    @responses.activate
+    def test_change_created(self):
+        """
+        The task should create a Change according to the details received from
+        the message sender
+        """
+        user = User.objects.create_user('test')
+        source = Source.objects.create(user=user)
+
+        responses.add(
+            responses.GET,
+            'http://ms/api/v1/outbound/?vumi_message_id=messageid',
+            json={
+                'results': [
+                    {
+                        'to_identity': 'test-identity-uuid',
+                    },
+                ]
+            }, status=200, match_querystring=True)
+
+        self.assertEqual(Change.objects.count(), 0)
+
+        process_whatsapp_unsent_event('messageid', source.pk)
+
+        [change] = Change.objects.all()
+        self.assertEqual(change.registrant_id, 'test-identity-uuid')
+        self.assertEqual(change.action, 'switch_channel')
+        self.assertEqual(change.data, {
+            'channel': 'sms',
+            'reason': 'whatsapp_unsent_event',
+        })
+        self.assertEqual(change.created_by, user)

--- a/changes/test_views.py
+++ b/changes/test_views.py
@@ -1,0 +1,69 @@
+from django.contrib.auth.models import User, Permission
+from django.urls import reverse
+from rest_framework import status
+from unittest import mock
+
+from rest_framework.test import APITestCase
+
+
+@mock.patch('changes.views.tasks.process_whatsapp_unsent_event')
+class ReceiveWhatsAppEventViewTests(APITestCase):
+    def test_permission_required(self, task):
+        """
+        The authenticated user must have permission to create a Change
+        """
+        user = User.objects.create_user('test')
+        self.client.force_authenticate(user=user)
+        url = reverse('whatsapp_event')
+
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        user.user_permissions.add(
+            Permission.objects.get(codename='add_change'))
+        user = User.objects.get(pk=user.pk)
+        self.client.force_authenticate(user=user)
+
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_serializer_failed(self, task):
+        """
+        If the serializer doesn't pass, then a 204 should be returned, and the
+        task shouldn't be called
+        """
+        user = User.objects.create_user('test')
+        user.user_permissions.add(
+            Permission.objects.get(codename='add_change'))
+        self.client.force_authenticate(user=user)
+        url = reverse('whatsapp_event')
+
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(task.called)
+
+    def test_serializer_succeeded(self, task):
+        """
+        If the serializer passes, then the task should be called with the
+        correct parameters
+        """
+        user = User.objects.create_user('test')
+        user.user_permissions.add(
+            Permission.objects.get(codename='add_change'))
+        self.client.force_authenticate(user=user)
+        url = reverse('whatsapp_event')
+
+        response = self.client.post(url, {
+            'hook': {
+                'event': 'message.direct_outbound.status',
+            },
+            'data': {
+                'message_metadata': {
+                    'junebug_message_id': '41c377a47b064eba9abee5a1ea827b3d',
+                },
+                'status': 'unsent',
+            },
+        }, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        task.delay.assert_called_once_with(
+            '41c377a47b064eba9abee5a1ea827b3d', user.pk)

--- a/changes/urls.py
+++ b/changes/urls.py
@@ -18,5 +18,7 @@ urlpatterns = [
         name="optout_admin"),
     url(r'^api/v1/change_admin/',
         views.ReceiveAdminChange.as_view(),
-        name="change_admin")
+        name="change_admin"),
+    url(r'^api/v1/whatsapp/event/', views.ReceiveWhatsAppEvent.as_view(),
+        name='whatsapp_event'),
 ]

--- a/ndoh_hub/utils.py
+++ b/ndoh_hub/utils.py
@@ -11,6 +11,7 @@ from seed_services_client.metrics import MetricsApiClient
 from seed_services_client.stage_based_messaging import (
     StageBasedMessagingApiClient)
 from seed_services_client.identity_store import IdentityStoreApiClient
+from seed_services_client.message_sender import MessageSenderApiClient
 
 
 ID_TYPES = ["sa_id", "passport", "none"]
@@ -38,6 +39,11 @@ sbm_client = StageBasedMessagingApiClient(
 is_client = IdentityStoreApiClient(
     api_url=settings.IDENTITY_STORE_URL,
     auth_token=settings.IDENTITY_STORE_TOKEN
+)
+
+ms_client = MessageSenderApiClient(
+    api_url=settings.MESSAGE_SENDER_URL,
+    auth_token=settings.MESSAGE_SENDER_TOKEN,
 )
 
 


### PR DESCRIPTION
We want to be able to switch users back to SMS if we ever get an unsent event from whatsapp. This will prevent users who do not have whatsapp installed not receiving messages because they switched to whatsapp messaging.