### PR TITLE
Fixes for automatic WhatsApp switch

### DIFF
--- a/changes/test_views.py
+++ b/changes/test_views.py
@@ -9,6 +9,18 @@ from rest_framework.test import APITestCase
 
 @mock.patch('changes.views.tasks.process_whatsapp_unsent_event')
 class ReceiveWhatsAppEventViewTests(APITestCase):
+    def test_no_auth(self, task):
+        """
+        If there is no or invalid auth supplied, a 401 error should be returned
+        """
+        url = reverse('whatsapp_event')
+
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        url = '{}?token=badtoken'.format(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
     def test_querystring_auth_token(self, task):
         """
         The token should be able to be specified in the query string

--- a/ndoh_hub/utils.py
+++ b/ndoh_hub/utils.py
@@ -336,4 +336,4 @@ class TokenAuthQueryString(TokenAuthentication):
         token = request.query_params.get('token', None)
         if token is not None:
             return self.authenticate_credentials(token)
-        return False
+        return None


### PR DESCRIPTION
If a token isn't supplied, we previously got an error, because the auth backend returned `False` instead of `None`. This has been fixed.

If we couldn't find an outbound for the ID specified in the event, then previously an error was raised. We should instead just skip the processing of this event