### PR TITLE
Add welcome message for jembi android app registrations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,103 @@
-.git
+# Docker-specific things:
+# Docker files
+Dockerfile
+*.dockerfile
+.dockerignore
+
+# Git files
+.git/
+**/.gitignore
+
+# Adapted from the standard Python .gitignore
+# https://github.com/github/gitignore/blob/master/Python.gitignore
+# 455a69dd48ce041f6ac2aa7aeeb9560957311e2f
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+**/*.mo
+**/*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
         - flake8
         - mypy registrations changes ndoh_hub
         - py.test
+        - createdb ndoh_hub
         - python manage.py makemigrations registrations changes --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)
 
     # Create docker image on merge to develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
 language: python
-python:
-  - "3.6"
-addons:
-  postgresql: "9.4"
-services:
-  - postgresql
-install:
-  - "pip install -r requirements.txt --use-wheel"
-  - "pip install -r requirements-dev.txt --use-wheel"
-script:
-  - flake8
-  - mypy registrations changes ndoh_hub
-  - py.test
-  - python manage.py makemigrations registrations changes --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)
 
 matrix:
   include:
+    # Run tests
+    - python:
+        - "3.6"
+      addons:
+        postgresql: "9.4"
+      services:
+        - postgresql
+      install:
+        - "pip install -r requirements.txt --use-wheel"
+        - "pip install -r requirements-dev.txt --use-wheel"
+      script:
+        - flake8
+        - mypy registrations changes ndoh_hub
+        - py.test
+        - python manage.py makemigrations registrations changes --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)
+
     # Create docker image on merge to develop
     - python: "2.7"
       sudo: required
@@ -40,10 +42,6 @@ matrix:
         on:
           branch: develop
 
-        # Inherited build steps that we don't want
-      install: []
-      addons: {}
-
     - python: "2.7"
       sudo: required
       dist: trusty
@@ -66,7 +64,3 @@ matrix:
         script: dcd --version "$(git tag -l --points-at HEAD)" --version-semver --version-latest "$IMAGE_NAME"
         on:
           tags: true
-
-        # Inherited build steps that we don't want
-      install: []
-      addons: {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     # Run tests
     - addons:
-        postgresql: "10.4"
+        postgresql: "9.4"
       services:
         - postgresql
         - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
       install:
         - "pip install -r requirements.txt --use-wheel"
         - "pip install -r requirements-dev.txt --use-wheel"
+        - django-admin compilemessages
       script:
         - flake8
         - mypy registrations changes ndoh_hub

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
+python: "3.6"
 
 matrix:
   include:
     # Run tests
-    - python:
-        - "3.6"
-      addons:
+    - addons:
         postgresql: "9.4"
       services:
         - postgresql
@@ -19,8 +18,7 @@ matrix:
         - python manage.py makemigrations registrations changes --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)
 
     # Create docker image on merge to develop
-    - python: "2.7"
-      sudo: required
+    - sudo: required
       dist: trusty
       services: [docker]
       env:
@@ -30,8 +28,10 @@ matrix:
         - secure: "HdNKmMAw+2K6APKFp/Cy5SVxFDDDtx83UeIA5h9mBF4wrjRQcNLwZCbDGQTKmeZ/HZZLqxj3H8k034Y1vw6iQRGvv2X5Jazanh6ett4zH6QNd8Tnk4CqsZZ7MIG71ZFaSbdotpq2KgWP//Sz2BlnzXugr2CWbydTDOGE3dyRwwphs8DXgUu2gOeSFVolf3H0zYbnWPkDyb4EB/lOsTETEXRN1F3jgwY58RQU6LAV/k/FAr4WDWE+qX8f9Kr13UhMJYKS8mouJsSU1Q2Uq/hMXz/2QZ1h8vdv/lV9l3JRcK7JOEwXRGyFNYVFpBMSzUQpb6OwcaLgiBQ25y4HLtrViiVGg1abGrWqXH2Uiv1gnkKsJ37VIXtR7gso7n48j7lNBUHdJUE6JdiktOlmt1KvLjGzdWyukmMpRB2Ci2KQkPbAqF7pxgC7Tq0x/XT+2M85g/xv+U9uP+SBPA5V1ZPaHntHgWKjjlU224tfXB/PhVRe3wSx2kHKQEHzbxGCB0i5bLkcVhMUxpuod6H6cYt5RqI3JQMWcQMup7suUyQKn8iu8oLeVAZIeJAEZRSLSUvFpvAvEmrNyflUtOLJ3eCCXaAgThej5ZNaH9np1yVMa8CVt3ccudA2l8M00oC2qu1qkgbY2SPePBkfo9htoUWJ7cQF0oGrim/TA4TBM6BQwOk="
       before_script:
         - docker pull "$IMAGE_NAME" || true
+        - pip install -r seaworthy/requirements.txt
       script:
         - docker build --tag "$IMAGE_NAME" --cache-from "$IMAGE_NAME" .
+        - (cd seaworthy; py.test -v --hub-image "$IMAGE_NAME" test.py)
 
       before_deploy:
         - pip install docker-ci-deploy==0.3.0
@@ -42,8 +42,8 @@ matrix:
         on:
           branch: develop
 
-    - python: "2.7"
-      sudo: required
+    # Create docker images for tagged releases
+    - sudo: required
       dist: trusty
       services: [docker]
       env:
@@ -53,8 +53,10 @@ matrix:
         - secure: "HdNKmMAw+2K6APKFp/Cy5SVxFDDDtx83UeIA5h9mBF4wrjRQcNLwZCbDGQTKmeZ/HZZLqxj3H8k034Y1vw6iQRGvv2X5Jazanh6ett4zH6QNd8Tnk4CqsZZ7MIG71ZFaSbdotpq2KgWP//Sz2BlnzXugr2CWbydTDOGE3dyRwwphs8DXgUu2gOeSFVolf3H0zYbnWPkDyb4EB/lOsTETEXRN1F3jgwY58RQU6LAV/k/FAr4WDWE+qX8f9Kr13UhMJYKS8mouJsSU1Q2Uq/hMXz/2QZ1h8vdv/lV9l3JRcK7JOEwXRGyFNYVFpBMSzUQpb6OwcaLgiBQ25y4HLtrViiVGg1abGrWqXH2Uiv1gnkKsJ37VIXtR7gso7n48j7lNBUHdJUE6JdiktOlmt1KvLjGzdWyukmMpRB2Ci2KQkPbAqF7pxgC7Tq0x/XT+2M85g/xv+U9uP+SBPA5V1ZPaHntHgWKjjlU224tfXB/PhVRe3wSx2kHKQEHzbxGCB0i5bLkcVhMUxpuod6H6cYt5RqI3JQMWcQMup7suUyQKn8iu8oLeVAZIeJAEZRSLSUvFpvAvEmrNyflUtOLJ3eCCXaAgThej5ZNaH9np1yVMa8CVt3ccudA2l8M00oC2qu1qkgbY2SPePBkfo9htoUWJ7cQF0oGrim/TA4TBM6BQwOk="
       before_script:
         - docker pull "$IMAGE_NAME" || true
+        - pip install -r seaworthy/requirements.txt
       script:
         - docker build --tag "$IMAGE_NAME" --cache-from "$IMAGE_NAME" .
+        - (cd seaworthy; py.test -v --hub-image "$IMAGE_NAME" test.py)
 
       before_deploy:
         - pip install docker-ci-deploy==0.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python: "3.6"
+cache: pip
 
 matrix:
   include:
     # Run tests
     - addons:
-        postgresql: "9.4"
+        postgresql: "10.4"
       services:
         - postgresql
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
         postgresql: "10.4"
       services:
         - postgresql
+        - redis-server
       install:
         - "pip install -r requirements.txt --use-wheel"
         - "pip install -r requirements-dev.txt --use-wheel"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM praekeltfoundation/django-bootstrap:py3.6
 COPY . /app
 COPY entrypoint.sh /scripts/django-entrypoint.sh
 COPY nginx.conf /etc/nginx/conf.d/django.conf
-RUN pip install -e .
+RUN pip install --no-cache-dir -e . 
 
 ENV DJANGO_SETTINGS_MODULE "ndoh_hub.settings"
 RUN ./manage.py collectstatic --noinput
+RUN apt-get-install.sh gettext; \
+    django-admin compilemessages; \
+    apt-get-purge.sh gettext
 CMD ["ndoh_hub.wsgi:application"]

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1228,6 +1228,7 @@ class PushOptoutToIdentityStore(Task):
                     'Problem posting Optout %s JSON to IdentityStore' % (
                         change_id), exc_info=True)
 
+
 push_optout_to_identity_store = PushOptoutToIdentityStore()
 
 

--- a/locale/afr_ZA/LC_MESSAGES/django.po
+++ b/locale/afr_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,29 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:36+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: afr_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"Welkom by MomConnect! Vir meer dienste bel %(popi_ussd)s, om te stop bel "
+"%(optout_ussd)s (gratis). Om na WhatsApp oor te skakel stuur “WA”. Standaard "
+"SMS fooie geld."

--- a/locale/eng_ZA/LC_MESSAGES/django.po
+++ b/locale/eng_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:36+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: eng_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."

--- a/locale/nbl_ZA/LC_MESSAGES/django.po
+++ b/locale/nbl_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:37+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: nbl_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"Wamukelwa kuMomConnect!Nawufuna kunengi dayela %(popi_ussd)s, ukulisa dayela "
+"%(optout_ussd)s (Mahala).Tjhinga kuWhatsApp, ngo“WA”.Kubiza imali "
+"ejayelekileko yeSMS."

--- a/locale/nso_ZA/LC_MESSAGES/django.po
+++ b/locale/nso_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:37+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: nso_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"O amogetšwe go MomConnect! Go hwetša ditirelo leletša%(popi_ussd)s, go emiša "
+"letša%(optout_ussd)s (Mahala).Go iša go WhatsApp, fetola WA. Go šoma "
+"ditefelo tša Std SMS."

--- a/locale/sot_ZA/LC_MESSAGES/django.po
+++ b/locale/sot_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:37+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: sot_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"Re o amohela MomConnect! Ditshebeletso tobetsa %(popi_ussd)s, emisa tobetsa "
+"%(optout_ussd)s (Mahala). Ho fetela WhatsApp, araba “WA”. Tlwaelo SMS "
+"direiti di sebetsa."

--- a/locale/ssw_ZA/LC_MESSAGES/django.po
+++ b/locale/ssw_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:37+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ssw_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"Umukelekile kuMomConnect! Kutfola tinsita letinyenti %(popi_ussd)s, yekela "
+"%(optout_ussd)s (Mahhala). Kuphendvula ngaWhatsApp, phendvula nga'WA'. I-SMS "
+"iyabhadalelwa."

--- a/locale/tsn_ZA/LC_MESSAGES/django.po
+++ b/locale/tsn_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:38+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: tsn_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"O amogetswe go MomConnect! Ditirelo tobetsa %(popi_ussd)s, go di khutlisa "
+"%(optout_ussd)s (Mahala). WhatsApp, romela lefoko \"WA\". Seelo sa disms se "
+"tla dirisiwa."

--- a/locale/tso_ZA/LC_MESSAGES/django.po
+++ b/locale/tso_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:38+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: tso_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"Ha ku amukela eka MomConnect!Ku kuma vukorhokeri dayila%(popi_ussd)s, ku "
+"tshika dayila%(optout_ussd)s mahala.Kuya eka WhatsApp, hlamula “WA”.Tihakelo "
+"ta SMS ta tirha."

--- a/locale/ven_ZA/LC_MESSAGES/django.po
+++ b/locale/ven_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:38+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ven_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"Vho ṱanganedzwa kha MomConnect! Tshumelo vha lidzele%(popi_ussd)s, u imisa "
+"vha lidzele %(optout_ussd)s (Mahala). WhatsApp vha fhindule WA. Hu shuma "
+"mutengo wa SMS."

--- a/locale/xho_ZA/LC_MESSAGES/django.po
+++ b/locale/xho_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:38+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: xho_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"Wamkelekile ku-MomConnect! Ngezinye iinkonzo, cofa u- %(popi_ussd)s, ukuyeka "
+"%(optout_ussd)s (Mahala). Ukuya ku-WhatsApp, yithi “WA”, ngemirhumo "
+"eqhelekileyo ye-SMS."

--- a/locale/zul_ZA/LC_MESSAGES/django.po
+++ b/locale/zul_ZA/LC_MESSAGES/django.po
@@ -1,0 +1,28 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-08 12:35+0200\n"
+"PO-Revision-Date: 2018-08-08 12:38+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zul_ZA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.1.1\n"
+
+#: registrations/tasks.py:757
+#, python-format
+msgid ""
+"Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
+"%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
+msgstr ""
+"Siyakwamukela kuMomConnect! Olunye usizo dayela %(popi_ussd)s, ukuphuma "
+"%(optout_ussd)s (Mahhala). Ukuya kuWhatsApp, ithi \"WA\". Kusebenza amanani "
+"ajwayelekile eSMS."

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -15,6 +15,7 @@ import djcelery
 import dj_database_url
 import mimetypes
 
+import django.conf.locale
 
 # Support SVG on admin
 mimetypes.add_type("image/svg+xml", ".svg", True)
@@ -148,6 +149,35 @@ USE_L10N = True
 
 USE_TZ = True
 
+LANGUAGES = [
+    ('afr-za', "Afrikaans"),
+    ('eng-za', "English"),
+    ('nbl-za', "isiNdebele"),
+    ('nso-za', "Sepedi"),
+    ('sot-za', "Sesotho"),
+    ('ssw-za', "Siswati"),
+    ('tsn-za', "Setswana"),
+    ('tso-za', "Xitsonga"),
+    ('ven-za', "Tshivenda"),
+    ('xho-za', "isiXhosa"),
+    ('zul-za', "isiZulu"),
+]
+
+LANG_INFO = {
+    lang[0]: {
+        'bidi': False,
+        'code': lang[0],
+        'name': lang[1],
+        'name_local': lang[1],
+    } for lang in LANGUAGES
+}
+
+LOCALE_PATHS = [
+    os.path.join(BASE_DIR, 'locale'),
+]
+
+# Add custom languages not provided by Django
+django.conf.locale.LANG_INFO = LANG_INFO
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
@@ -312,3 +342,6 @@ WASSUP_NUMBER = os.environ.get('WASSUP_NUMBER', '+27820000000')
 
 NURSECONNECT_RTHB = os.environ.get(
     'NURSECONNECT_RTHB', 'false').lower() == 'true'
+
+POPI_USSD_CODE = os.environ.get('POPI_USSD_CODE', '*134*550*7#')
+OPTOUT_USSD_CODE = os.environ.get('OPTOUT_USSD_CODE', '*134*550*1#')

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -51,12 +51,12 @@ INSTALLED_APPS = (
     'rest_framework_docs',
     # 3rd party
     'djcelery',
+    'channels',
     'raven.contrib.django.raven_compat',
     'rest_framework',
     'rest_framework.authtoken',
     'django_filters',
     'rest_hooks',
-    'channels',
     'simple_history',
     # us
     'registrations',

--- a/seaworthy/conftest.py
+++ b/seaworthy/conftest.py
@@ -1,0 +1,13 @@
+import os
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--hub-image", action="store", default=os.environ.get(
+            "HUB_IMAGE", "praekeltfoundation/ndoh-hub:develop"),
+        help="NDOH Hub image to test"
+    )
+
+
+def pytest_report_header(config):
+    return "NDOH Hub Docker image: {}".format(config.getoption("--hub-image"))

--- a/seaworthy/fixtures.py
+++ b/seaworthy/fixtures.py
@@ -1,0 +1,39 @@
+import pytest
+from seaworthy.definitions import ContainerDefinition
+from seaworthy.containers.postgresql import PostgreSQLContainer
+
+HUB_IMAGE = pytest.config.getoption("--hub-image")
+
+
+class HubContainer(ContainerDefinition):
+    WAIT_PATTERNS = (r"Listening at: unix:/var/run/gunicorn/gunicorn.sock",)
+
+    def __init__(self, name, db_url, image=HUB_IMAGE):
+        super().__init__(name, image, self.WAIT_PATTERNS)
+        self.db_url = db_url
+
+    def base_kwargs(self):
+        return {
+            "ports": {
+                "8000/tcp": None,
+            },
+            "environment": {
+                "HUB_DATABASE": self.db_url,
+            },
+        }
+
+
+postgresql_container = PostgreSQLContainer("postgresql")
+postgresql_fixture, clean_postgresql_fixture = (
+    postgresql_container.pytest_clean_fixtures("postgresql_container")
+)
+
+hub_container = HubContainer("ndoh-hub", postgresql_container.database_url())
+hub_fixture = hub_container.pytest_fixture(
+    "hub_container", dependencies=["postgresql_container"])
+
+__all__ = [
+    "clean_postgresql_fixture",
+    "hub_fixture",
+    "postgresql_fixture",
+]

--- a/seaworthy/requirements.txt
+++ b/seaworthy/requirements.txt
@@ -1,0 +1,1 @@
+seaworthy[pytest] >= 0.3.0

--- a/seaworthy/test.py
+++ b/seaworthy/test.py
@@ -1,0 +1,34 @@
+import cgi
+
+from fixtures import *  # noqa: F401,F403
+
+
+def mime_type(content_type):
+    return cgi.parse_header(content_type)[0]
+
+
+class TestHubContainer:
+    def test_db_tables_created(self, hub_container, postgresql_container):
+        """
+        When the Django container starts, it should run its migrations
+        """
+        django_logs = hub_container.get_logs().decode("utf-8")
+        assert "Running migrations" in django_logs
+
+        psql_output = postgresql_container.exec_psql(
+            ("SELECT COUNT(*) FROM information_schema.tables WHERE "
+             "table_schema='public';")
+        )
+        count = int(psql_output.output.strip())
+        assert count > 0
+
+    def test_admin_page(self, hub_container, postgresql_container):
+        """
+        When we try to access the django admin page, it should be returned
+        """
+        client = hub_container.http_client()
+        response = client.get("/admin")
+
+        assert response.status_code == 200
+        assert mime_type(response.headers["content-type"]) == "text/html"
+        assert "<title>Log in | Django site admin</title>" in response.text

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 exclude = */migrations/*.py,*/manage.py,ve/*
 
 [tool:pytest]
-python_files=test*.py
+python_files=registrations/test*.py registrations/**/test*.py changes/test*.py changes/**/test*.py
 addopts = --verbose --ds=ndoh_hub.testsettings --ignore=ve --cov=ndoh_hub --cov=registrations --cov=changes --no-cov-on-fail
 
 [coverage:run]

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'Framework :: Django',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
 )


### PR DESCRIPTION
For the USSD registrations, the USSD app makes the API call to the message sender to send the welcome message. Jembi's android app, however, cannot do this, so we must add it as part of the registration task.

This PR adds translation support, so that the message is in the correct language, adds the message sending as part of the registration task, as well as some travis config fixes, and seaworthy tests for the docker image