### PR TITLE
Create subscriptions for service info messages for new registrations

### DIFF
--- a/ndoh_hub/utils.py
+++ b/ndoh_hub/utils.py
@@ -272,6 +272,11 @@ def get_messageset_schedule_sequence(short_name, weeks):
         if weeks >= 32:
             next_sequence_number = ((weeks - 30) * msgs_per_week) - 2
 
+    # WhatsApp service info messages depend on months pregnant
+    elif 'whatsapp_service_info.hw_full.1' in short_name:
+        if weeks >= 5:
+            next_sequence_number = ((weeks - 4) // 4) + 1
+
     # other momconnect_prebirth sets start at 1
 
     # loss subscriptions always start at 1

--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -138,6 +138,7 @@ def mock_get_messageset_by_shortname(short_name):
         "whatsapp_momconnect_prebirth.hw_full.1": 93,
         "whatsapp_momconnect_postbirth.hw_full.1": 93,
         "whatsapp_momconnect_prebirth.hw_full.2": 94,
+        "whatsapp_service_info.hw_full.1": 95,
     }[short_name]
 
     default_schedule = {
@@ -171,6 +172,7 @@ def mock_get_messageset_by_shortname(short_name):
         "whatsapp_momconnect_prebirth.hw_full.1": 192,
         "whatsapp_momconnect_postbirth.hw_full.1": 192,
         "whatsapp_momconnect_prebirth.hw_full.2": 122,
+        "whatsapp_service_info.hw_full.1": 123,
     }[short_name]
 
     responses.add(

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -458,6 +458,7 @@ class ValidateSubscribe(Task):
         if reg_validates:
             self.create_subscriptionrequests(registration)
             self.create_popi_subscriptionrequest(registration)
+            self.create_service_info_subscriptionrequest(registration)
 
             # NOTE: disable service rating for now
             # if registration.reg_type == "momconnect_prebirth" and\
@@ -848,6 +849,7 @@ class ValidateSubscribeJembiAppRegistration(HTTPRetryMixin, ValidateSubscribe):
         # Create subscriptions
         self.create_subscriptionrequests(registration)
         self.create_popi_subscriptionrequest(registration)
+        self.create_service_info_subscriptionrequest(registration)
 
         # Send welcome message
         self.send_welcome_message(

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -325,6 +325,34 @@ class ValidateSubscribe(Task):
         self.log.info("POPI Subscription request created")
         return "POPI Subscription Request created"
 
+    def create_service_info_subscriptionrequest(self, registration):
+        """
+        Creates a new subscription request for the service info message set.
+        This should only be created for momconnect whatsapp registrations.
+        """
+        if registration.reg_type != 'whatsapp_prebirth':
+            return
+
+        self.log.info("Fetching messageset")
+
+        weeks = utils.get_pregnancy_week(
+            utils.get_today(), registration.data["edd"])
+        msgset_short_name = utils.get_messageset_short_name(
+            'whatsapp_service_info', registration.source.authority, weeks)
+        msgset_id, msgset_schedule, next_sequence_number =\
+            utils.get_messageset_schedule_sequence(msgset_short_name, weeks)
+
+        self.log.info("Creating subscription request")
+        from .models import SubscriptionRequest
+        SubscriptionRequest.objects.create(
+            identity=registration.registrant_id,
+            messageset=msgset_id,
+            next_sequence_number=next_sequence_number,
+            lang=registration.data['language'],
+            schedule=msgset_schedule,
+        )
+        self.log.info("Service Info Subscription request created")
+
     # Create SubscriptionRequest
     def create_subscriptionrequests(self, registration):
         """ Create SubscriptionRequest(s) based on the


### PR DESCRIPTION
This PR creates subscriptions to the new service info messages for all new whatsapp registrations, placing them in the correct position of the service info messageset according to their EDD.