### PR TITLE
Add management command for creating service info subscriptions for existing whatsapp users

### DIFF
--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -268,6 +268,17 @@ def mock_get_messageset(messageset_id):
     )
 
 
+def mock_get_messagesets(messagesets):
+    responses.add(
+        responses.GET,
+        "http://sbm/api/v1/messageset/",
+        json={
+            "results": messagesets,
+        },
+        match_querystring=True,
+    )
+
+
 def mock_get_schedule(schedule_id):
     day_of_week = {
         111: "1",

--- a/registrations/management/commands/service_info_subscriptions.py
+++ b/registrations/management/commands/service_info_subscriptions.py
@@ -52,6 +52,11 @@ class Command(BaseCommand):
         })["results"]
 
         for subscription in subscriptions:
+            messageset = messageset_mapping[subscription["messageset"]]
+            if "hw_full" not in messageset:
+                # We only want to subscribe full clinic subscriptions
+                continue
+
             if self.identity_has_service_info_subscription(
                     messageset_mapping, subscription["identity"]):
                 # They already have an active service info subscription, skip
@@ -61,7 +66,7 @@ class Command(BaseCommand):
                 continue
 
             sequence = self.service_info_sequence(
-                messageset_mapping[subscription["messageset"]],
+                messageset,
                 subscription["next_sequence_number"]
             )
             self.log.debug(

--- a/registrations/management/commands/service_info_subscriptions.py
+++ b/registrations/management/commands/service_info_subscriptions.py
@@ -85,18 +85,44 @@ class Command(BaseCommand):
         Calculates the sequence number that the service info messageset should
         be on, given the existing subscription that a user has
         """
-        # TODO: work out the actual logic here
-        # whatsapp_momconnect_prebirth.hw_partial.1
-        # whatsapp_momconnect_postbirth.hw_full.1
-        # whatsapp_momconnect_postbirth.hw_full.2
-        # whatsapp_momconnect_prebirth.hw_full.1
-        # whatsapp_momconnect_prebirth.hw_full.2
-        # whatsapp_momconnect_prebirth.hw_full.3
-        # whatsapp_momconnect_prebirth.hw_full.4
-        # whatsapp_momconnect_prebirth.hw_full.5
-        # whatsapp_momconnect_prebirth.hw_full.6
-        # whatsapp_momconnect_prebirth.patient.1
-        return 1
+        def calculate_position(frequency: int, offset: int) -> int:
+            """
+            Given the weekly frequency, and the weekly offset, calculate the
+            monthly positions
+            """
+            weeks = ((sequence - 1) // frequency) + offset
+            return (weeks // 4) + 1
+
+        # Service info messages are once a month
+        # Weeks described below are weeks of messaging, not weeks of pregnancy
+        if short_name == "whatsapp_momconnect_prebirth.hw_full.1":
+            # Twice a week, starts at week 0, 74 messages
+            return calculate_position(2, 0)
+        if short_name == "whatsapp_momconnect_prebirth.hw_full.2":
+            # Three times a week, starts at week 26, 31 messages
+            return calculate_position(3, 26)
+        if short_name == "whatsapp_momconnect_prebirth.hw_full.3":
+            # Three times a week, starts at week 31, 15 messages
+            return calculate_position(3, 31)
+        if short_name == "whatsapp_momconnect_prebirth.hw_full.4":
+            # Four times a week, starts at week 32, 15 messages
+            return calculate_position(4, 32)
+        if short_name == "whatsapp_momconnect_prebirth.hw_full.5":
+            # Five times a week, starts at week 33, 15 messages
+            return calculate_position(5, 33)
+        if short_name == "whatsapp_momconnect_prebirth.hw_full.6":
+            # Seven times a week, starts at week 34, 15 messages
+            return calculate_position(7, 34)
+        if short_name == "whatsapp_momconnect_postbirth.hw_full.1":
+            # Twice a week, starts at week 37, 30 messages
+            return calculate_position(2, 37)
+        if short_name == "whatsapp_momconnect_postbirth.hw_full.2":
+            # Once a week, starts at week 52, 38 messages
+            return calculate_position(1, 52)
+        if short_name == "whatsapp_momconnect_postbirth.hw_full.3":
+            # Three times a week, starts at week 90, 156 messages
+            return calculate_position(3, 90)
+        raise ValueError("{} is not expected".format(short_name))
 
     def identity_has_service_info_subscription(
             self, messageset_mapping: dict, identity: str) -> bool:

--- a/registrations/management/commands/service_info_subscriptions.py
+++ b/registrations/management/commands/service_info_subscriptions.py
@@ -45,7 +45,6 @@ class Command(BaseCommand):
 
         service_info_messageset = next(sbm_client.get_messagesets(
             {"short_name": "whatsapp_service_info.hw_full.1"})["results"])
-        print(service_info_messageset)
 
         subscriptions = sbm_client.get_subscriptions({
             "messageset_contains": "whatsapp_momconnect_",

--- a/registrations/management/commands/service_info_subscriptions.py
+++ b/registrations/management/commands/service_info_subscriptions.py
@@ -1,0 +1,115 @@
+from os import environ
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from registrations.models import SubscriptionRequest
+
+from ndoh_hub.utils import sbm_client
+
+
+class Command(BaseCommand):
+    log = logging.getLogger("registrations")
+    help = ('Subscribes all current WhatsApp subscription users to the '
+            'correct place in the service info messageset')
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--sbm-url', dest='sbm_url',
+            default=environ.get('STAGE_BASED_MESSAGING_URL'),
+            help=('The Stage Based Messaging Service for '
+                  'service info subscriptions'))
+        parser.add_argument(
+            '--sbm-token', dest='sbm_token',
+            default=environ.get('STAGE_BASED_MESSAGING_TOKEN'),
+            help=('The Authorization token for the SBM Service')
+        )
+
+    def handle(self, *args, **kwargs):
+        sbm_url = kwargs['sbm_url']
+        sbm_token = kwargs['sbm_token']
+
+        if not sbm_url:
+            raise CommandError(
+                'Please make sure either the STAGE_BASED_MESSAGING_URL '
+                'environment variable or --sbm-url is set.')
+
+        if not sbm_token:
+            raise CommandError(
+                'Please make sure either the STAGE_BASED_MESSAGING_TOKEN '
+                'environment variable or --sbm-token is set.')
+
+        messageset_mapping = {
+            ms['id']: ms['short_name']
+            for ms in sbm_client.get_messagesets()["results"]
+        }
+
+        service_info_messageset = next(sbm_client.get_messagesets(
+            {"short_name": "whatsapp_service_info.hw_full.1"})["results"])
+        print(service_info_messageset)
+
+        subscriptions = sbm_client.get_subscriptions({
+            "messageset_contains": "whatsapp_momconnect_",
+            "active": True,
+        })["results"]
+
+        for subscription in subscriptions:
+            if self.identity_has_service_info_subscription(
+                    messageset_mapping, subscription["identity"]):
+                # They already have an active service info subscription, skip
+                self.log.debug(
+                    "%s already has a service info subscription, skipping",
+                    subscription["identity"])
+                continue
+
+            sequence = self.service_info_sequence(
+                messageset_mapping[subscription["messageset"]],
+                subscription["next_sequence_number"]
+            )
+            self.log.debug(
+                "Creating service info subscription request for %s",
+                subscription["identity"])
+            SubscriptionRequest.objects.create(
+                identity=subscription["identity"],
+                messageset=service_info_messageset["id"],
+                next_sequence_number=sequence,
+                lang=subscription["lang"],
+                schedule=service_info_messageset["default_schedule"],
+            )
+
+    def service_info_sequence(self, short_name: str, sequence: int) -> int:
+        """
+        Calculates the sequence number that the service info messageset should
+        be on, given the existing subscription that a user has
+        """
+        # TODO: work out the actual logic here
+        # whatsapp_momconnect_prebirth.hw_partial.1
+        # whatsapp_momconnect_postbirth.hw_full.1
+        # whatsapp_momconnect_postbirth.hw_full.2
+        # whatsapp_momconnect_prebirth.hw_full.1
+        # whatsapp_momconnect_prebirth.hw_full.2
+        # whatsapp_momconnect_prebirth.hw_full.3
+        # whatsapp_momconnect_prebirth.hw_full.4
+        # whatsapp_momconnect_prebirth.hw_full.5
+        # whatsapp_momconnect_prebirth.hw_full.6
+        # whatsapp_momconnect_prebirth.patient.1
+        return 1
+
+    def identity_has_service_info_subscription(
+            self, messageset_mapping: dict, identity: str) -> bool:
+        """
+        Whether or not the given identity has an active subscription to the
+        service info messageset.
+
+        Args:
+            messageset_mapping (dict):
+                Mapping between messageset keys and names
+            identity (str): The UUID of the identity
+        """
+        subscriptions = [
+            messageset_mapping[sub["messageset"]] for sub in
+            sbm_client.get_subscriptions({
+                "active": True,
+                "identity": identity,
+            })["results"]
+        ]
+        return "whatsapp_service_info.hw_full.1" in subscriptions

--- a/registrations/management/commands/tests/test_service_info_subscriptions.py
+++ b/registrations/management/commands/tests/test_service_info_subscriptions.py
@@ -1,0 +1,95 @@
+from django.core.management import call_command
+from django.test import TestCase
+import responses
+
+from ndoh_hub import utils_tests
+from registrations.management.commands.service_info_subscriptions import (
+    Command)
+from registrations.models import SubscriptionRequest
+
+
+class ServiceInfoSubscriptionsTests(TestCase):
+    @responses.activate
+    def test_identity_has_service_info_subscription_true(self):
+        """
+        If the identity has an active service info subscription, should return
+        True
+        """
+        utils_tests.mock_get_subscriptions(
+            "?active=True&identity=identity-uuid", [
+                {"messageset": 1}, {"messageset": 2}])
+        cmd = Command()
+        res = cmd.identity_has_service_info_subscription({
+            1: "whatsapp_momconnect_prebirth.hw_full.1",
+            2: "whatsapp_service_info.hw_full.1",
+            3: "whatsapp_popi.hw_full.1",
+        }, "identity-uuid")
+        self.assertTrue(res)
+
+    @responses.activate
+    def test_identity_has_service_info_subscription_false(self):
+        """
+        If the identity does not have an active service info subscription,
+        should return False
+        """
+        utils_tests.mock_get_subscriptions(
+            "?active=True&identity=identity-uuid", [
+                {"messageset": 1}, {"messageset": 3}])
+        cmd = Command()
+        res = cmd.identity_has_service_info_subscription({
+            1: "whatsapp_momconnect_prebirth.hw_full.1",
+            2: "whatsapp_service_info.hw_full.1",
+            3: "whatsapp_popi.hw_full.1",
+        }, "identity-uuid")
+        self.assertFalse(res)
+
+    @responses.activate
+    def test_service_info_subscriptions(self):
+        """
+        For each identity that has an active subscription, should create a
+        service info subscription request if they don't already have one.
+        """
+        utils_tests.mock_get_messagesets([
+            {"id": 1, "short_name": "whatsapp_momconnect_prebirth.hw_full.1"},
+            {"id": 2, "short_name": "whatsapp_service_info.hw_full.1"},
+            {"id": 3, "short_name": "whatsapp_popi.hw_full.1"},
+        ])
+        utils_tests.mock_get_messageset_by_shortname(
+            "whatsapp_service_info.hw_full.1")
+        utils_tests.mock_get_subscriptions(
+            "?active=True&messageset_contains=whatsapp_momconnect_", [
+                {
+                    "identity": "identity-uuid1",
+                    "lang": "zul_ZA",
+                    "messageset": 1,
+                    "sequence_number": 5,
+                    "next_sequence_number": 3,
+                },
+                {
+                    "identity": "identity-uuid2",
+                    "lang": "sso_ZA",
+                    "messageset": 1,
+                    "sequence_number": 7,
+                    "next_sequence_number": 5,
+                },
+            ]
+        )
+        utils_tests.mock_get_subscriptions(
+            "?active=True&identity=identity-uuid1", [
+                {"messageset": 1}, {"messageset": 2}])
+        utils_tests.mock_get_subscriptions(
+            "?active=True&identity=identity-uuid2", [
+                {"messageset": 1}, {"messageset": 3}])
+
+        call_command(
+            "service_info_subscriptions",
+            "--sbm-url", "http://sbm/",
+            "--sbm-token", "sbmtoken"
+        )
+
+        [subreq] = SubscriptionRequest.objects.all()
+        self.assertEqual(subreq.messageset, 95)
+        self.assertEqual(subreq.identity, "identity-uuid2")
+        self.assertEqual(subreq.next_sequence_number, 1)
+        self.assertEqual(subreq.lang, "sso_ZA")
+        self.assertEqual(subreq.schedule, 123)

--- a/registrations/management/commands/tests/test_service_info_subscriptions.py
+++ b/registrations/management/commands/tests/test_service_info_subscriptions.py
@@ -52,12 +52,13 @@ class ServiceInfoSubscriptionsTests(TestCase):
         utils_tests.mock_get_messagesets([
             {"id": 1, "short_name": "whatsapp_momconnect_prebirth.hw_full.1"},
             {"id": 2, "short_name": "whatsapp_service_info.hw_full.1"},
-            {"id": 3, "short_name": "whatsapp_popi.hw_full.1"},
+            {"id": 3, "short_name": "whatsapp_momconnect_prebirth.patient.1"},
         ])
         utils_tests.mock_get_messageset_by_shortname(
             "whatsapp_service_info.hw_full.1")
         utils_tests.mock_get_subscriptions(
             "?active=True&messageset_contains=whatsapp_momconnect_", [
+                # already has service info subscription
                 {
                     "identity": "identity-uuid1",
                     "lang": "zul_ZA",
@@ -65,10 +66,19 @@ class ServiceInfoSubscriptionsTests(TestCase):
                     "sequence_number": 5,
                     "next_sequence_number": 3,
                 },
+                # should get service subscription added
                 {
                     "identity": "identity-uuid2",
                     "lang": "sso_ZA",
                     "messageset": 1,
+                    "sequence_number": 7,
+                    "next_sequence_number": 5,
+                },
+                # subscription is not for full messageset
+                {
+                    "identity": "identity-uuid2",
+                    "lang": "sso_ZA",
+                    "messageset": 3,
                     "sequence_number": 7,
                     "next_sequence_number": 5,
                 },


### PR DESCRIPTION
https://github.com/praekeltfoundation/ndoh-hub/pull/162 added subscriptions to the service info messageset for new WhatsApp registrations.

This PR adds a management command to subscribe existing WhatsApp users to the service info messageset, in the correct location.