### PR TITLE
Handle all engage failed types

### DIFF
--- a/changes/serializers.py
+++ b/changes/serializers.py
@@ -47,14 +47,14 @@ class AdminChangeSerializer(serializers.Serializer):
 
 class ReceiveWhatsAppEventSerializer(serializers.Serializer):
 
-    class HookSerializer(serializers.Serializer):
-        event = serializers.ChoiceField(['message.direct_outbound.status'])
-    hook = HookSerializer()
+    class StatusSerializer(serializers.Serializer):
 
-    class EventSerializer(serializers.Serializer):
-        status = serializers.ChoiceField(['unsent'])
+        class ErrorSerializer(serializers.Serializer):
+            code = serializers.CharField(required=False)
+            title = serializers.CharField(required=True)
 
-        class MessageMetadata(serializers.Serializer):
-            junebug_message_id = serializers.UUIDField()
-        message_metadata = MessageMetadata()
-    data = EventSerializer()
+        id = serializers.CharField(required=True)
+        status = serializers.ChoiceField(['failed'])
+        errors = serializers.ListField(child=ErrorSerializer(), default=[])
+
+    statuses = serializers.ListField(child=StatusSerializer(), min_length=1)

--- a/changes/serializers.py
+++ b/changes/serializers.py
@@ -54,7 +54,20 @@ class ReceiveWhatsAppEventSerializer(serializers.Serializer):
             title = serializers.CharField(required=True)
 
         id = serializers.CharField(required=True)
-        status = serializers.ChoiceField(['failed'])
+        status = serializers.ChoiceField(
+            ["failed", "sent", "delivered", "read"])
         errors = serializers.ListField(child=ErrorSerializer(), default=[])
 
     statuses = serializers.ListField(child=StatusSerializer(), min_length=1)
+
+    def to_internal_value(self, data):
+        if "statuses" in data:
+            statuses = []
+            for status in data["statuses"]:
+                if(status["status"] == "failed"):
+                    statuses.append(status)
+
+            data["statuses"] = statuses
+
+        return super(ReceiveWhatsAppEventSerializer, self).to_internal_value(
+            data)

--- a/changes/test_serializers.py
+++ b/changes/test_serializers.py
@@ -6,100 +6,72 @@ from changes.serializers import ReceiveWhatsAppEventSerializer
 class ReceiveWhatsAppEventSerializerTests(TestCase):
     def test_valid(self):
         serializer = ReceiveWhatsAppEventSerializer(data={
-            'hook': {
-                'event': 'message.direct_outbound.status',
-            },
-            'data': {
-                'id': 12345,
-                'message_uuid': '8773bd92-a28a-438d-942b-3b8aca3a216e',
-                'contact_uuid': 'f87e5256-f26d-4e96-97b4-ed5e4d462a33',
-                'group_uuid': None,
-                'message_metadata': {
-                    'wassup_reply': {},
-                    'junebug_reply_to': None,
-                    'junebug_message_id': '41c377a47b064eba9abee5a1ea827b3d',
+            "statuses": [
+                {
+                    "errors": [
+                        {"code": 500, "title": "structure unavailable: Client could not display highly structured message"}  # noqa
+                    ],
+                    "id": "41c377a47b064eba9abee5a1ea827b3d",
+                    "recipient_id": "27831112222",
+                    "status": "failed",
+                    "timestamp": "1538388353"
                 },
-                'uuid': '8ec6b95a-f43e-4000-8f4d-bf3e359bb3e',
-                'status': 'unsent',
-                'description': None,
-                'timestamp': '2018-04-19T09:36:38Z',
-                'created_at': '2018-04-19T09:36:38.842036Z',
-                'updated_at': '2018-04-19T09:36:38.842054Z',
-                'message': 12346,
-                'contact': 12347,
-            },
+                {
+                    "errors": [
+                        {"code": 500, "title": "structure unavailable: Client could not display highly structured message"}  # noqa
+                    ],
+                    "id": "kdmfglkdfmlgkdfmgkdmlfkgmdlfkgdm",
+                    "recipient_id": "27831114444",
+                    "status": "failed",
+                    "timestamp": "1538388354"
+                }
+            ]
         })
 
         self.assertTrue(serializer.is_valid())
-
-    def test_invalid_incorrect_event(self):
-        """
-        If the event is not message.direct_outbound.status, then the serializer
-        should be invalid
-        """
-        serializer = ReceiveWhatsAppEventSerializer(data={
-            'hook': {
-                'event': 'message.direct_outbound',
-            },
-            'data': {
-                'message_metadata': {
-                    'junebug_message_id': '41c377a47b064eba9abee5a1ea827b3d',
-                },
-                'status': 'unsent',
-            },
-        })
-
-        self.assertFalse(serializer.is_valid())
-        self.assertEqual(serializer.errors, {
-            'hook': {
-                'event': ['"message.direct_outbound" is not a valid choice.'],
-            },
-        })
 
     def test_invalid_incorrect_status(self):
         """
         If the status is not unsent, then the serializer should be invalid
         """
         serializer = ReceiveWhatsAppEventSerializer(data={
-            'hook': {
-                'event': 'message.direct_outbound.status',
-            },
-            'data': {
-                'message_metadata': {
-                    'junebug_message_id': '41c377a47b064eba9abee5a1ea827b3d',
-                },
-                'status': 'sent',
-            },
+            "statuses": [
+                {
+                    "id": "kdmfglkdfmlgkdfmgkdmlfkgmdlfkgdm",
+                    "recipient_id": "27831114444",
+                    "status": "sent",
+                    "timestamp": "1538388354"
+                }
+            ]
         })
 
         self.assertFalse(serializer.is_valid())
         self.assertEqual(serializer.errors, {
-            'data': {
+            'statuses': {
                 'status': ['"sent" is not a valid choice.'],
             },
         })
 
-    def test_invalid_incorrect_junebug_message_id(self):
+    def test_invalid_missing_message_id(self):
         """
-        junebug_message_id must be present, and must be a valid UUID.
+        id must be present.
         """
         serializer = ReceiveWhatsAppEventSerializer(data={
-            'hook': {
-                'event': 'message.direct_outbound.status',
-            },
-            'data': {
-                'message_metadata': {
-                    'junebug_message_id': 'bad-uuid',
-                },
-                'status': 'unsent',
-            },
+            "statuses": [
+                {
+                    "errors": [
+                        {"code": 500, "title": "structure unavailable: Client could not display highly structured message"}  # noqa
+                    ],
+                    "recipient_id": "27831112222",
+                    "status": "failed",
+                    "timestamp": "1538388353"
+                }
+            ]
         })
 
         self.assertFalse(serializer.is_valid())
         self.assertEqual(serializer.errors, {
-            'data': {
-                'message_metadata': {
-                    'junebug_message_id': ['"bad-uuid" is not a valid UUID.'],
-                },
-            },
+            'statuses': {
+                'id': ['This field is required.']
+            }
         })

--- a/changes/test_serializers.py
+++ b/changes/test_serializers.py
@@ -30,12 +30,18 @@ class ReceiveWhatsAppEventSerializerTests(TestCase):
 
         self.assertTrue(serializer.is_valid())
 
-    def test_invalid_incorrect_status(self):
-        """
-        If the status is not unsent, then the serializer should be invalid
-        """
+    def test_valid_and_invalid(self):
         serializer = ReceiveWhatsAppEventSerializer(data={
             "statuses": [
+                {
+                    "errors": [
+                        {"code": 500, "title": "structure unavailable: Client could not display highly structured message"}  # noqa
+                    ],
+                    "id": "41c377a47b064eba9abee5a1ea827b3d",
+                    "recipient_id": "27831112222",
+                    "status": "failed",
+                    "timestamp": "1538388353"
+                },
                 {
                     "id": "kdmfglkdfmlgkdfmgkdmlfkgmdlfkgdm",
                     "recipient_id": "27831114444",
@@ -45,11 +51,30 @@ class ReceiveWhatsAppEventSerializerTests(TestCase):
             ]
         })
 
+        self.assertTrue(serializer.is_valid())
+        statuses = serializer.validated_data["statuses"]
+        self.assertEqual(len(statuses), 1)
+        self.assertEqual(statuses[0]["status"], "failed")
+
+    def test_invalid_incorrect_status(self):
+        """
+        If the status is not unsent, then the serializer should be invalid
+        """
+        serializer = ReceiveWhatsAppEventSerializer(data={
+            "statuses": [
+                {
+                    "id": "kdmfglkdfmlgkdfmgkdmlfkgmdlfkgdm",
+                    "recipient_id": "27831114444",
+                    "status": "sending",
+                    "timestamp": "1538388354"
+                }
+            ]
+        })
+
         self.assertFalse(serializer.is_valid())
         self.assertEqual(serializer.errors, {
-            'statuses': {
-                'status': ['"sent" is not a valid choice.'],
-            },
+            'statuses':
+                ['Ensure this field has at least 1 elements.']
         })
 
     def test_invalid_missing_message_id(self):

--- a/changes/test_views.py
+++ b/changes/test_views.py
@@ -1,3 +1,4 @@
+import json
 from django.contrib.auth.models import User, Permission
 from django.urls import reverse
 from rest_framework import status
@@ -7,9 +8,10 @@ from unittest import mock
 from rest_framework.test import APITestCase
 
 
+@mock.patch('changes.views.ReceiveWhatsAppEvent.validate_signature')
 @mock.patch('changes.views.tasks.process_whatsapp_unsent_event')
 class ReceiveWhatsAppEventViewTests(APITestCase):
-    def test_no_auth(self, task):
+    def test_no_auth(self, task, mock_validate_signature):
         """
         If there is no or invalid auth supplied, a 401 error should be returned
         """
@@ -21,7 +23,7 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
         url = '{}?token=badtoken'.format(url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_querystring_auth_token(self, task):
+    def test_querystring_auth_token(self, task, mock_validate_signature):
         """
         The token should be able to be specified in the query string
         """
@@ -35,7 +37,7 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    def test_permission_required(self, task):
+    def test_permission_required(self, task, mock_validate_signature):
         """
         The authenticated user must have permission to create a Change
         """
@@ -54,7 +56,7 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    def test_serializer_failed(self, task):
+    def test_serializer_failed(self, task, mock_validate_signature):
         """
         If the serializer doesn't pass, then a 204 should be returned, and the
         task shouldn't be called
@@ -69,7 +71,7 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(task.called)
 
-    def test_serializer_succeeded(self, task):
+    def test_serializer_succeeded(self, task, mock_validate_signature):
         """
         If the serializer passes, then the task should be called with the
         correct parameters
@@ -81,16 +83,89 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
         url = reverse('whatsapp_event')
 
         response = self.client.post(url, {
-            'hook': {
-                'event': 'message.direct_outbound.status',
-            },
-            'data': {
-                'message_metadata': {
-                    'junebug_message_id': '41c377a47b064eba9abee5a1ea827b3d',
-                },
-                'status': 'unsent',
-            },
+            "statuses": [
+                {
+                    "errors": [
+                        {"code": 500, "title": "structure unavailable: Client could not display highly structured message"}  # noqa
+                    ],
+                    "id": "41c377a47b064eba9abee5a1ea827b3d",
+                    "recipient_id": "27831112222",
+                    "status": "failed",
+                    "timestamp": "1538388353"
+                }
+            ]
         }, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        task.delay.assert_called_once_with(
+            '41c377a47b064eba9abee5a1ea827b3d', user.pk)
+
+
+@mock.patch('changes.views.tasks.process_whatsapp_unsent_event')
+class ValidateSignatureTests(APITestCase):
+    def test_no_hvac_header(self, task):
+        """
+        If there is no X-Engage-Hook-Signature, auth error should be raised
+        """
+        user = User.objects.create_user('test')
+        user.user_permissions.add(
+            Permission.objects.get(codename='add_change'))
+        self.client.force_authenticate(user=user)
+        url = reverse('whatsapp_event')
+
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(
+            json.loads(response.content)["detail"],
+            "X-Engage-Hook-Signature header required")
+
+    def test_invalid_hvac_header(self, task):
+        """
+        If there is a invalid X-Engage-Hook-Signature, auth error should be
+        raised
+        """
+        user = User.objects.create_user('test')
+        user.user_permissions.add(
+            Permission.objects.get(codename='add_change'))
+        self.client.force_authenticate(user=user)
+        url = reverse('whatsapp_event')
+
+        header = {'X-Engage-Hook-Signature': 'SECRET'}
+
+        response = self.client.post(url, data={}, headers=header)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(
+            json.loads(response.content)["detail"],
+            "Invalid hook signature")
+
+    def test_valid_hvac_header(self, task):
+        """
+        If there is a valid X-Engage-Hook-Signature, no auth error should be
+        raised
+        """
+        user = User.objects.create_user('test')
+        user.user_permissions.add(
+            Permission.objects.get(codename='add_change'))
+        self.client.force_authenticate(user=user)
+        url = reverse('whatsapp_event')
+
+        header = {'X-Engage-Hook-Signature':
+                  'Gu7dfV2kfjbT6PJ/J7N7xi4/d+y91Ys9ISMxQRxhac8='}
+
+        response = self.client.post(url, data={
+            "statuses": [
+                {
+                    "errors": [
+                        {"code": 500, "title": "structure unavailable: Client could not display highly structured message"}  # noqa
+                    ],
+                    "id": "41c377a47b064eba9abee5a1ea827b3d",
+                    "recipient_id": "27831112222",
+                    "status": "failed",
+                    "timestamp": "1538388353"
+                }
+            ]
+        }, format="json", headers=header)
+
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         task.delay.assert_called_once_with(
             '41c377a47b064eba9abee5a1ea827b3d', user.pk)

--- a/changes/views.py
+++ b/changes/views.py
@@ -7,9 +7,7 @@ from rest_framework import viewsets, mixins, generics, status
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.exceptions import ValidationError, AuthenticationFailed
 from rest_framework.pagination import CursorPagination
-from rest_framework.permissions import (
-    IsAuthenticated, AllowAny, DjangoModelPermissions
-)
+from rest_framework.permissions import IsAuthenticated, DjangoModelPermissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from .models import Source, Change

--- a/changes/views.py
+++ b/changes/views.py
@@ -205,7 +205,7 @@ class ReceiveAdminChange(generics.CreateAPIView):
 
 
 class ReceiveWhatsAppEvent(generics.GenericAPIView):
-    permission_classes = (AllowAny, DjangoModelPermissions)
+    permission_classes = (IsAuthenticated, DjangoModelPermissions)
     queryset = Change.objects.none()
     serializer_class = ReceiveWhatsAppEventSerializer
     authentication_classes = (TokenAuthQueryString, TokenAuthentication)

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -345,3 +345,5 @@ NURSECONNECT_RTHB = os.environ.get(
 
 POPI_USSD_CODE = os.environ.get('POPI_USSD_CODE', '*134*550*7#')
 OPTOUT_USSD_CODE = os.environ.get('OPTOUT_USSD_CODE', '*134*550*1#')
+
+ENGAGE_HMAC_SECRET = os.environ.get('ENGAGE_HMAC_SECRET', 'REPLACEME')


### PR DESCRIPTION
This only updates the endpoint to work with the new engage format and auth.

Still need to handle each event properly and send notification.