### PR TITLE
Handle HSM errors appropriately

### DIFF
--- a/changes/serializers.py
+++ b/changes/serializers.py
@@ -50,7 +50,7 @@ class ReceiveWhatsAppEventSerializer(serializers.Serializer):
     class StatusSerializer(serializers.Serializer):
 
         class ErrorSerializer(serializers.Serializer):
-            code = serializers.CharField(required=False)
+            code = serializers.IntegerField(required=False)
             title = serializers.CharField(required=True)
 
         id = serializers.CharField(required=True)

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -1,7 +1,9 @@
+import responses
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.test import TestCase
-import responses
+from unittest import mock
+
 
 from registrations.models import Source
 from changes.models import Change
@@ -18,8 +20,9 @@ class ProcessWhatsAppUnsentEventTaskTests(TestCase):
         post_save.connect(
             receiver=psh_validate_implement, sender=Change)
 
+    @mock.patch('changes.tasks.utils.ms_client.create_outbound')
     @responses.activate
-    def test_change_created(self):
+    def test_change_created(self, mock_create_outbound):
         """
         The task should create a Change according to the details received from
         the message sender
@@ -40,7 +43,11 @@ class ProcessWhatsAppUnsentEventTaskTests(TestCase):
 
         self.assertEqual(Change.objects.count(), 0)
 
-        process_whatsapp_unsent_event('messageid', source.pk)
+        process_whatsapp_unsent_event('messageid', source.pk, [{
+            'code': 500,
+            "title": "structure unavailable: Client could not display highly "
+                     "structured message"}
+        ])
 
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, 'test-identity-uuid')
@@ -50,6 +57,16 @@ class ProcessWhatsAppUnsentEventTaskTests(TestCase):
             'reason': 'whatsapp_unsent_event',
         })
         self.assertEqual(change.created_by, user)
+
+        mock_create_outbound.assert_called_once_with({
+            'to_identity': 'test-identity-uuid',
+            'content':
+                "Sorry, we can't send WhatsApp msgs to this phone. We'll send "
+                "your MomConnect msgs on SMS. To stop dial *134*550*1#, for "
+                "more dial *134*550*7#.",
+            'channel': "JUNE_TEXT",
+            'metadata': {},
+        })
 
     @responses.activate
     def test_no_outbound_message(self):
@@ -69,6 +86,38 @@ class ProcessWhatsAppUnsentEventTaskTests(TestCase):
 
         self.assertEqual(Change.objects.count(), 0)
 
-        process_whatsapp_unsent_event('messageid', source.pk)
+        process_whatsapp_unsent_event('messageid', source.pk, [{
+            'code': 500,
+            "title": "structure unavailable: Client could not display highly "
+                     "structured message"}
+        ])
+
+        self.assertEqual(Change.objects.count(), 0)
+
+    @responses.activate
+    def test_non_hsm_failure(self):
+        """
+        The task should not create a switch if it is not a hsm failure
+        """
+        user = User.objects.create_user('test')
+        source = Source.objects.create(user=user)
+
+        responses.add(
+            responses.GET,
+            'http://ms/api/v1/outbound/?vumi_message_id=messageid',
+            json={
+                'results': [
+                    {
+                        'to_identity': 'test-identity-uuid',
+                    },
+                ]
+            }, status=200, match_querystring=True)
+
+        self.assertEqual(Change.objects.count(), 0)
+
+        process_whatsapp_unsent_event('messageid', source.pk, [{
+            'code': 200,
+            "title": "random error: temporary random error"}
+        ])
 
         self.assertEqual(Change.objects.count(), 0)

--- a/changes/test_views.py
+++ b/changes/test_views.py
@@ -82,12 +82,14 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
         self.client.force_authenticate(user=user)
         url = reverse('whatsapp_event')
 
+        errors = [
+            {"code": 500, "title": "structure unavailable: Client could not display highly structured message"}  # noqa
+        ]
+
         response = self.client.post(url, {
             "statuses": [
                 {
-                    "errors": [
-                        {"code": 500, "title": "structure unavailable: Client could not display highly structured message"}  # noqa
-                    ],
+                    "errors": errors,
                     "id": "41c377a47b064eba9abee5a1ea827b3d",
                     "recipient_id": "27831112222",
                     "status": "failed",
@@ -97,7 +99,7 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
         }, format='json')
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         task.delay.assert_called_once_with(
-            '41c377a47b064eba9abee5a1ea827b3d', user.pk)
+            '41c377a47b064eba9abee5a1ea827b3d', user.pk, errors)
 
 
 @mock.patch('changes.views.tasks.process_whatsapp_unsent_event')
@@ -152,12 +154,14 @@ class ValidateSignatureTests(APITestCase):
         header = {'X-Engage-Hook-Signature':
                   'Gu7dfV2kfjbT6PJ/J7N7xi4/d+y91Ys9ISMxQRxhac8='}
 
+        errors = [
+            {"code": 500, "title": "structure unavailable: Client could not display highly structured message"}  # noqa
+        ]
+
         response = self.client.post(url, data={
             "statuses": [
                 {
-                    "errors": [
-                        {"code": 500, "title": "structure unavailable: Client could not display highly structured message"}  # noqa
-                    ],
+                    "errors": errors,
                     "id": "41c377a47b064eba9abee5a1ea827b3d",
                     "recipient_id": "27831112222",
                     "status": "failed",
@@ -168,4 +172,4 @@ class ValidateSignatureTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         task.delay.assert_called_once_with(
-            '41c377a47b064eba9abee5a1ea827b3d', user.pk)
+            '41c377a47b064eba9abee5a1ea827b3d', user.pk, errors)

--- a/changes/views.py
+++ b/changes/views.py
@@ -233,6 +233,7 @@ class ReceiveWhatsAppEvent(generics.GenericAPIView):
             tasks.process_whatsapp_unsent_event.delay(
                 item["id"],
                 request.user.pk,
+                item["errors"]
             )
 
         return Response(status=status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
This change will only do the switch to SMS on the correct errors, time based failures will be dealt with in another endpoint.

I still need to do the translations.