### PR TITLE
Add system event handler

### DIFF
--- a/changes/serializers.py
+++ b/changes/serializers.py
@@ -71,3 +71,13 @@ class ReceiveWhatsAppEventSerializer(serializers.Serializer):
 
         return super(ReceiveWhatsAppEventSerializer, self).to_internal_value(
             data)
+
+
+class ReceiveWhatsAppSystemEventSerializer(serializers.Serializer):
+
+    class EventSerializer(serializers.Serializer):
+        type = serializers.CharField(required=True)
+        message_id = serializers.CharField(required=True)
+        recipient_id = serializers.CharField(required=True)
+
+    events = serializers.ListField(child=EventSerializer(), min_length=1)

--- a/changes/test_serializers.py
+++ b/changes/test_serializers.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
-from changes.serializers import ReceiveWhatsAppEventSerializer
+from changes.serializers import (
+    ReceiveWhatsAppEventSerializer, ReceiveWhatsAppSystemEventSerializer)
 
 
 class ReceiveWhatsAppEventSerializerTests(TestCase):
@@ -98,5 +99,50 @@ class ReceiveWhatsAppEventSerializerTests(TestCase):
         self.assertEqual(serializer.errors, {
             'statuses': {
                 'id': ['This field is required.']
+            }
+        })
+
+
+class ReceiveWhatsAppSystemEventSerializerTests(TestCase):
+
+    def test_valid(self):
+        serializer = ReceiveWhatsAppSystemEventSerializer(data={
+            "events": [
+                {
+                    "recipient_id": "27831112222",
+                    "timestamp": "1538388353",
+                    "message_id": "gBGGJ4NjeFMfAgl58_8Il_tnCNI",
+                    "type": "undelivered"
+                }, {
+                    "recipient_id": "27831113333",
+                    "timestamp": "1538388354",
+                    "message_id": "gBGGJ4NjeFMfAgl58_8Il_WWWWW",
+                    "type": "something_else"
+                }
+            ]
+        })
+
+        self.assertTrue(serializer.is_valid())
+
+    def test_missing_message_id(self):
+        serializer = ReceiveWhatsAppSystemEventSerializer(data={
+            "events": [
+                {
+                    "recipient_id": "27831112222",
+                    "timestamp": "1538388353",
+                    "type": "undelivered"
+                }, {
+                    "recipient_id": "27831113333",
+                    "timestamp": "1538388354",
+                    "message_id": "gBGGJ4NjeFMfAgl58_8Il_WWWWW",
+                    "type": "undelivered"
+                }
+            ]
+        })
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors, {
+            'events': {
+                'message_id': ['This field is required.']
             }
         })

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -205,6 +205,9 @@ class ProcessWhatsAppSystemEventTaskTests(WhatsAppBaseTestCase):
         """
         self.create_outbound_lookup(0)
 
-        process_whatsapp_system_event('messageid', "something_else")
+        process_whatsapp_system_event('messageid', "undelivered")
 
+        self.assertEqual(
+            responses.calls[0].request.url,
+            "http://ms/api/v1/outbound/?vumi_message_id=messageid")
         self.assertFalse(mock_create_outbound.called)

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -8,28 +8,23 @@ from unittest import mock
 from registrations.models import Source
 from changes.models import Change
 from changes.signals import psh_validate_implement
-from changes.tasks import process_whatsapp_unsent_event
+from changes.tasks import (
+    process_whatsapp_unsent_event, process_whatsapp_system_event)
 
 
-class ProcessWhatsAppUnsentEventTaskTests(TestCase):
-    def setUp(self):
-        post_save.disconnect(
-            receiver=psh_validate_implement, sender=Change)
+class WhatsAppBaseTestCase(TestCase):
 
-    def tearDown(self):
-        post_save.connect(
-            receiver=psh_validate_implement, sender=Change)
+    def create_outbound_lookup(self, result_count=1):
 
-    def create_outbound_lookup(self):
+        results = []
+        for i in range(0, result_count):
+            results.append({'to_identity': 'test-identity-uuid'})
+
         responses.add(
             responses.GET,
             'http://ms/api/v1/outbound/?vumi_message_id=messageid',
             json={
-                'results': [
-                    {
-                        'to_identity': 'test-identity-uuid',
-                    },
-                ]
+                'results': results
             }, status=200, match_querystring=True)
 
     def create_identity_lookup(self, lang="eng_ZA"):
@@ -43,6 +38,16 @@ class ProcessWhatsAppUnsentEventTaskTests(TestCase):
                 }
             },
             status=200, match_querystring=True)
+
+
+class ProcessWhatsAppUnsentEventTaskTests(WhatsAppBaseTestCase):
+    def setUp(self):
+        post_save.disconnect(
+            receiver=psh_validate_implement, sender=Change)
+
+    def tearDown(self):
+        post_save.connect(
+            receiver=psh_validate_implement, sender=Change)
 
     @mock.patch('changes.tasks.utils.ms_client.create_outbound')
     @responses.activate
@@ -124,12 +129,7 @@ class ProcessWhatsAppUnsentEventTaskTests(TestCase):
         user = User.objects.create_user('test')
         source = Source.objects.create(user=user)
 
-        responses.add(
-            responses.GET,
-            'http://ms/api/v1/outbound/?vumi_message_id=messageid',
-            json={
-                'results': []
-            }, status=200, match_querystring=True)
+        self.create_outbound_lookup(0)
 
         self.assertEqual(Change.objects.count(), 0)
 
@@ -149,16 +149,7 @@ class ProcessWhatsAppUnsentEventTaskTests(TestCase):
         user = User.objects.create_user('test')
         source = Source.objects.create(user=user)
 
-        responses.add(
-            responses.GET,
-            'http://ms/api/v1/outbound/?vumi_message_id=messageid',
-            json={
-                'results': [
-                    {
-                        'to_identity': 'test-identity-uuid',
-                    },
-                ]
-            }, status=200, match_querystring=True)
+        self.create_outbound_lookup(1)
 
         self.assertEqual(Change.objects.count(), 0)
 
@@ -168,3 +159,52 @@ class ProcessWhatsAppUnsentEventTaskTests(TestCase):
         ])
 
         self.assertEqual(Change.objects.count(), 0)
+
+
+class ProcessWhatsAppSystemEventTaskTests(WhatsAppBaseTestCase):
+
+    @mock.patch('changes.tasks.utils.ms_client.create_outbound')
+    @responses.activate
+    def test_message_sent_delivered(self, mock_create_outbound):
+        """
+        The task should send the correct outbound based on the delivered event.
+        """
+        self.create_outbound_lookup()
+        self.create_identity_lookup()
+
+        process_whatsapp_system_event('messageid', "undelivered")
+
+        mock_create_outbound.assert_called_once_with({
+            'to_identity': 'test-identity-uuid',
+            'content':
+                "We see that your MomConnect WhatsApp messages are not being "
+                "delivered. If you would like to receive your messages over "
+                "SMS, reply ‘SMS’.",
+            'channel': "JUNE_TEXT",
+            'metadata': {},
+        })
+
+    @mock.patch('changes.tasks.utils.ms_client.create_outbound')
+    @responses.activate
+    def test_no_message_sent(self, mock_create_outbound):
+        """
+        The task should not create a Outbound when the event is the wrong type.
+        """
+        self.create_outbound_lookup()
+
+        process_whatsapp_system_event('messageid', "something_else")
+
+        self.assertFalse(mock_create_outbound.called)
+
+    @mock.patch('changes.tasks.utils.ms_client.create_outbound')
+    @responses.activate
+    def test_no_message_found(self, mock_create_outbound):
+        """
+        The task should not create a outbound if the original message was not
+        found
+        """
+        self.create_outbound_lookup(0)
+
+        process_whatsapp_system_event('messageid', "something_else")
+
+        self.assertFalse(mock_create_outbound.called)

--- a/changes/test_views.py
+++ b/changes/test_views.py
@@ -130,7 +130,7 @@ class ReceiveWhatsAppSystemEventViewTests(APITestCase):
 
     def test_serializer_failed(self, task, mock_validate_signature):
         """
-        If the serializer doesn't pass, then a 204 should be returned, and the
+        If the serializer doesn't pass, then a 400 should be returned, and the
         task shouldn't be called
         """
         user = User.objects.create_user('test')
@@ -146,7 +146,7 @@ class ReceiveWhatsAppSystemEventViewTests(APITestCase):
                 "type": "undelivered"
             }]
         })
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(task.called)
 
 

--- a/changes/test_views.py
+++ b/changes/test_views.py
@@ -8,7 +8,7 @@ from unittest import mock
 from rest_framework.test import APITestCase
 
 
-@mock.patch('changes.views.ReceiveWhatsAppEvent.validate_signature')
+@mock.patch('changes.views.ReceiveWhatsAppBase.validate_signature')
 @mock.patch('changes.views.tasks.process_whatsapp_unsent_event')
 class ReceiveWhatsAppEventViewTests(APITestCase):
     def test_no_auth(self, task, mock_validate_signature):
@@ -100,6 +100,54 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         task.delay.assert_called_once_with(
             '41c377a47b064eba9abee5a1ea827b3d', user.pk, errors)
+
+
+@mock.patch('changes.views.ReceiveWhatsAppBase.validate_signature')
+@mock.patch('changes.views.tasks.process_whatsapp_system_event')
+class ReceiveWhatsAppSystemEventViewTests(APITestCase):
+    def test_serializer_succeeded(self, task, mock_validate_signature):
+        """
+        If the serializer passes, then the task should be called with the
+        correct parameters
+        """
+        user = User.objects.create_user('test')
+        user.user_permissions.add(
+            Permission.objects.get(codename='add_change'))
+        self.client.force_authenticate(user=user)
+        url = reverse('whatsapp_system_event')
+
+        response = self.client.post(url, {
+            "events": [{
+                "recipient_id": "278311155555",
+                "timestamp": "1538388353",
+                "message_id": "gBGGJ4NjeFMfAgl58_8Il_tnCNI",
+                "type": "undelivered"
+            }]
+        }, format='json')
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        task.delay.assert_called_once_with('gBGGJ4NjeFMfAgl58_8Il_tnCNI',
+                                           "undelivered")
+
+    def test_serializer_failed(self, task, mock_validate_signature):
+        """
+        If the serializer doesn't pass, then a 204 should be returned, and the
+        task shouldn't be called
+        """
+        user = User.objects.create_user('test')
+        user.user_permissions.add(
+            Permission.objects.get(codename='add_change'))
+        self.client.force_authenticate(user=user)
+        url = reverse('whatsapp_system_event')
+
+        response = self.client.post(url, {
+            "events": [{
+                "recipient_id": "278311155555",
+                "timestamp": "1538388353",
+                "type": "undelivered"
+            }]
+        })
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(task.called)
 
 
 @mock.patch('changes.views.tasks.process_whatsapp_unsent_event')

--- a/changes/urls.py
+++ b/changes/urls.py
@@ -21,4 +21,7 @@ urlpatterns = [
         name="change_admin"),
     url(r'^api/v1/whatsapp/event/', views.ReceiveWhatsAppEvent.as_view(),
         name='whatsapp_event'),
+    url(r'^api/v1/whatsapp/system_event/',
+        views.ReceiveWhatsAppSystemEvent.as_view(),
+        name='whatsapp_system_event'),
 ]

--- a/changes/views.py
+++ b/changes/views.py
@@ -249,8 +249,7 @@ class ReceiveWhatsAppSystemEvent(ReceiveWhatsAppBase):
         self.validate_signature(request)
         serializer = self.get_serializer(data=request.data)
         if not serializer.is_valid():
-            # If this isn't an event that we care about
-            return Response(status=status.HTTP_204_NO_CONTENT)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
         for item in serializer.validated_data["events"]:
             tasks.process_whatsapp_system_event.delay(item["message_id"],

--- a/changes/views.py
+++ b/changes/views.py
@@ -13,7 +13,7 @@ from rest_framework.views import APIView
 from .models import Source, Change
 from .serializers import (
     ChangeSerializer, AdminOptoutSerializer, AdminChangeSerializer,
-    ReceiveWhatsAppEventSerializer,
+    ReceiveWhatsAppEventSerializer, ReceiveWhatsAppSystemEventSerializer
 )
 from seed_services_client.stage_based_messaging import StageBasedMessagingApiClient  # noqa
 from django.conf import settings
@@ -202,10 +202,9 @@ class ReceiveAdminChange(generics.CreateAPIView):
                             status=status.HTTP_400_BAD_REQUEST)
 
 
-class ReceiveWhatsAppEvent(generics.GenericAPIView):
+class ReceiveWhatsAppBase(generics.GenericAPIView):
     permission_classes = (IsAuthenticated, DjangoModelPermissions)
     queryset = Change.objects.none()
-    serializer_class = ReceiveWhatsAppEventSerializer
     authentication_classes = (TokenAuthQueryString, TokenAuthentication)
 
     def validate_signature(self, request):
@@ -222,6 +221,10 @@ class ReceiveWhatsAppEvent(generics.GenericAPIView):
         if base64.b64encode(h.digest()) != signature.encode():
             raise AuthenticationFailed("Invalid hook signature")
 
+
+class ReceiveWhatsAppEvent(ReceiveWhatsAppBase):
+    serializer_class = ReceiveWhatsAppEventSerializer
+
     def post(self, request, *args, **kwargs):
         self.validate_signature(request)
         serializer = self.get_serializer(data=request.data)
@@ -235,5 +238,22 @@ class ReceiveWhatsAppEvent(generics.GenericAPIView):
                 request.user.pk,
                 item["errors"]
             )
+
+        return Response(status=status.HTTP_202_ACCEPTED)
+
+
+class ReceiveWhatsAppSystemEvent(ReceiveWhatsAppBase):
+    serializer_class = ReceiveWhatsAppSystemEventSerializer
+
+    def post(self, request, *args, **kwargs):
+        self.validate_signature(request)
+        serializer = self.get_serializer(data=request.data)
+        if not serializer.is_valid():
+            # If this isn't an event that we care about
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+        for item in serializer.validated_data["events"]:
+            tasks.process_whatsapp_system_event.delay(item["message_id"],
+                                                      item["type"])
 
         return Response(status=status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
This PR adds a system event handler coming from engage.

For now we are only handling `undelivered` which means a message was not delivered in a week and no messages sent after it has been delivered.

We use this to notify the user that they can switch to SMS.

Translation support is there but we don't have the translations yet.