### PR TITLE
Add webhook receiver for message sender events

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,3 +269,11 @@ To release a version for production purposes, update the version in setup.py,
 and tag the commit that updates the version to the version that it updates to,
 and then push that tag. A new docker image and tag will be created according to
 the version specified in the git tag.
+
+## Translations
+To update the translation files from the source, run:
+
+    django-admin makemessages -a
+
+You can then use a tool like POEdit to update the PO files with the relevant
+translations

--- a/changes/fields.py
+++ b/changes/fields.py
@@ -1,0 +1,32 @@
+import phonenumbers
+from rest_framework import serializers
+
+
+class PhoneNumberField(serializers.Field):
+    """
+    Phone Numbers are serialized into E164 international format
+    """
+    default_error_messages = {
+        "cannot_parse": "Cannot parse: {error}",
+        "not_possible": "Not a possible phone number",
+        "not_valid": "Not a valid phone number",
+    }
+
+    def __init__(self, *args, country_code=None, **kwargs):
+        self.country_code = country_code
+        return super().__init__(*args, **kwargs)
+
+    def to_representation(self, obj):
+        return phonenumbers.format_number(
+            obj, phonenumbers.PhoneNumberFormat.E164)
+
+    def to_internal_value(self, data):
+        try:
+            p = phonenumbers.parse(data, self.country_code)
+        except phonenumbers.phonenumberutil.NumberParseException as e:
+            self.fail('cannot_parse', error=str(e))
+        if not phonenumbers.is_possible_number(p):
+            self.fail("not_possible")
+        if not phonenumbers.is_valid_number(p):
+            self.fail("not_valid")
+        return p

--- a/changes/serializers.py
+++ b/changes/serializers.py
@@ -1,5 +1,7 @@
-from .models import Change
 from rest_framework import serializers
+
+from .fields import PhoneNumberField
+from .models import Change
 
 
 class OneFieldRequiredValidator:
@@ -81,3 +83,18 @@ class ReceiveWhatsAppSystemEventSerializer(serializers.Serializer):
         recipient_id = serializers.CharField(required=True)
 
     events = serializers.ListField(child=EventSerializer(), min_length=1)
+
+
+class SeedMessageSenderHookSerializer(serializers.Serializer):
+    class Hook(serializers.Serializer):
+        id = serializers.IntegerField()
+        event = serializers.ChoiceField(
+            choices=["whatsapp.failed_contact_check"])
+        target = serializers.CharField()
+
+    hook = Hook()
+
+    class Data(serializers.Serializer):
+        address = PhoneNumberField(country_code="ZA")
+
+    data = Data()

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1378,7 +1378,8 @@ class ProcessWhatsAppContactCheckFail(Task):
 
     def run(self, user_id: int, address: str, **kwargs) -> None:
         results = list(
-            utils.is_client.get_identity_by_address("msisdn", address)["results"])
+            utils.is_client.get_identity_by_address("msisdn", address)[
+                "results"])
         if len(results) == 0:
             # We don't have any identities with this address
             return
@@ -1407,7 +1408,6 @@ class ProcessWhatsAppContactCheckFail(Task):
                 "keep sending your MomConnect messages on SMS."
             )
 
-        print(text)
         utils.ms_client.create_outbound({
             'to_identity': identity_uuid,
             'content': text,

--- a/changes/test_fields.py
+++ b/changes/test_fields.py
@@ -1,0 +1,61 @@
+from unittest import TestCase
+
+from rest_framework.serializers import ValidationError
+
+from changes.fields import PhoneNumberField
+import phonenumbers
+
+
+class PhoneNumberFieldTests(TestCase):
+    def test_valid_number(self):
+        """
+        If a valid phone number is supplied, then a valid PhoneNumber should be
+        returned.
+        """
+        number = PhoneNumberField().to_internal_value("+27820001001")
+        self.assertEqual(number.country_code, 27)
+        self.assertEqual(number.national_number, 820001001)
+
+    def test_country_code(self):
+        """
+        If a country code is supplied, it should be used when interpreting the
+        number.
+        """
+        number = PhoneNumberField(country_code="ZA").to_internal_value(
+            "0820001001")
+        self.assertEqual(number.country_code, 27)
+
+    def test_cannot_parse(self):
+        """
+        If the supplied data cannot be parsed as a phone number, a validation
+        exception should be raised
+        """
+        with self.assertRaises(ValidationError) as e:
+            PhoneNumberField().to_internal_value("bad")
+        self.assertIn("Cannot parse", str(e.exception))
+
+    def test_not_possible_number(self):
+        """
+        If the supplied number is not possible, a validation exception should
+        be raised
+        """
+        with self.assertRaises(ValidationError) as e:
+            PhoneNumberField().to_internal_value("+120012301")
+        self.assertIn("Not a possible phone number", str(e.exception))
+
+    def test_not_valid_phone_number(self):
+        """
+        If the supplied number is not valid, a validation exception should be
+        raised
+        """
+        with self.assertRaises(ValidationError) as e:
+            PhoneNumberField().to_internal_value("+12001230101")
+        self.assertIn("Not a valid phone number", str(e.exception))
+
+    def test_to_representation(self):
+        """
+        The phone number should be in E164 format for representation
+        """
+        number = phonenumbers.parse("0820001001", "ZA")
+        self.assertEqual(
+            PhoneNumberField().to_representation(number), "+27820001001")

--- a/changes/test_views.py
+++ b/changes/test_views.py
@@ -238,7 +238,7 @@ class ReceiveSeedMessageSenderHookViewTests(APITestCase):
     def test_whatsapp_contact_check_failure(self, task):
         """
         If the message sender sends us an event for whatsapp contact check fail
-        then we should run the processing task.        
+        then we should run the processing task.
         """
         user = User.objects.create_user("test")
         token = Token.objects.create(user=user).key

--- a/changes/test_views.py
+++ b/changes/test_views.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 from unittest import mock
+from urllib.parse import urlencode
 
 from rest_framework.test import APITestCase
 
@@ -221,3 +222,40 @@ class ValidateSignatureTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         task.delay.assert_called_once_with(
             '41c377a47b064eba9abee5a1ea827b3d', user.pk, errors)
+
+
+class ReceiveSeedMessageSenderHookViewTests(APITestCase):
+    def test_token_querystring_auth(self):
+        """
+        The token should be required in the querystring for requests to be
+        processed.
+        """
+        url = reverse('message_sender_webhook')
+        response = self.client.post(url, data={}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @mock.patch('changes.views.tasks.process_whatsapp_contact_check_fail')
+    def test_whatsapp_contact_check_failure(self, task):
+        """
+        If the message sender sends us an event for whatsapp contact check fail
+        then we should run the processing task.        
+        """
+        user = User.objects.create_user("test")
+        token = Token.objects.create(user=user).key
+        url = "{}?{}".format(reverse('message_sender_webhook'), urlencode({
+            "token": token
+        }))
+
+        response = self.client.post(url, data={
+            "hook": {
+                "id": 1,
+                "event": "whatsapp.failed_contact_check",
+                "target": "http://example.org",
+            },
+            "data": {
+                "address": "+27820001001",
+            },
+        }, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        task.delay.assert_called_once_with(str(user.pk), "+27820001001")

--- a/changes/urls.py
+++ b/changes/urls.py
@@ -24,4 +24,7 @@ urlpatterns = [
     url(r'^api/v1/whatsapp/system_event/',
         views.ReceiveWhatsAppSystemEvent.as_view(),
         name='whatsapp_system_event'),
+    url(r'^api/v1/message_sender/webhook/',
+        views.SeedMessageSenderHook.as_view(),
+        name='message_sender_webhook'),
 ]

--- a/locale/afr_ZA/LC_MESSAGES/django.po
+++ b/locale/afr_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 15:45+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:27+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: afr_ZA\n"
@@ -18,7 +18,32 @@ msgstr ""
 "X-Generator: Poedit 2.1.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Jammer ons kan nie WhatsApp boodskappe na hd foon stuur nie. MomConnect sal "
+"boodskappe via SMS stuur. Om te stop skakel %(optout_ussd)s vir meer skakel "
+"%(popi_ussd)s."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+"Ag nee! Jy kan nie MomConnect boodskappe via WhatsApp kry nie. Ons sal "
+"aanhou om dit via SMS te stuur."
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -27,11 +52,3 @@ msgstr ""
 "Welkom by MomConnect! Vir meer dienste bel %(popi_ussd)s, om te stop bel "
 "%(optout_ussd)s (gratis). Om na WhatsApp oor te skakel stuur “WA”. Standaard "
 "SMS fooie geld."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Jammer ons kan nie WhatsApp boodskappe na hd foon stuur nie. MomConnect sal "
-"boodskappe via SMS stuur. Om te stop skakel %(optout_ussd)s vir meer skakel "
-"%(popi_ussd)s."

--- a/locale/eng_ZA/LC_MESSAGES/django.po
+++ b/locale/eng_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 16:30+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:28+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: eng_ZA\n"
@@ -17,7 +17,33 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
+"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -25,10 +51,3 @@ msgid ""
 msgstr ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
 "%(optout_ussd)s (Free). To move to WhatsApp, reply “WA”. Std SMS rates apply."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."

--- a/locale/nbl_ZA/LC_MESSAGES/django.po
+++ b/locale/nbl_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 15:52+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:29+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: nbl_ZA\n"
@@ -17,7 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Siyacolisa, asikghoni ukuthumela imilayezo yeWhatsApp kilefoni.Sizayithumela "
+"ngeSMS. Ukulisa dayela %(optout_ussd)s, ukufumana kunengi dayela"
+"%(popi_ussd)s."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+"Awa! Angeze wathola imilayezwakho yeMomConnect kuWhatsApp. Sizakuhlala "
+"siyithumela ngeSMS."
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -26,11 +51,3 @@ msgstr ""
 "Wamukelwa kuMomConnect!Nawufuna kunengi dayela %(popi_ussd)s, ukulisa dayela "
 "%(optout_ussd)s (Mahala).Tjhinga kuWhatsApp, ngo“WA”.Kubiza imali "
 "ejayelekileko yeSMS."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Siyacolisa, asikghoni ukuthumela imilayezo yeWhatsApp kilefoni.Sizayithumela "
-"ngeSMS. Ukulisa dayela %(optout_ussd)s, ukufumana kunengi dayela"
-"%(popi_ussd)s."

--- a/locale/nso_ZA/LC_MESSAGES/django.po
+++ b/locale/nso_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 16:13+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:31+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: nso_ZA\n"
@@ -17,7 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Tshwarelo ga re romele melaetša yaWhatsApp founung ye. Re romela melaetša ya "
+"MomConnect ka SMS. Emiša ka %(optout_ussd)s, hwetša tše ntši taela"
+"%(popi_ussd)s."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+"Ao! O ka se hwetše melaetša ya MomConnect ka WhatsApp. Re tla dula re go "
+"romela melaetša ya gago ya MomConnect ka SMS."
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -26,11 +51,3 @@ msgstr ""
 "O amogetšwe go MomConnect! Go hwetša ditirelo leletša%(popi_ussd)s, go emiša "
 "letša%(optout_ussd)s (Mahala).Go iša go WhatsApp, fetola WA. Go šoma "
 "ditefelo tša Std SMS."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Tshwarelo ga re romele melaetša yaWhatsApp founung ye. Re romela melaetša ya "
-"MomConnect ka SMS. Emiša ka %(optout_ussd)s, hwetša tše ntši taela"
-"%(popi_ussd)s."

--- a/locale/sot_ZA/LC_MESSAGES/django.po
+++ b/locale/sot_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 16:13+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:32+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: sot_ZA\n"
@@ -17,7 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Tshwarelo, re ke ke ra romela melaetsa WhatsApp founung ena. Re tla romella "
+"melaetsa MomConnect ka SMS. Ho emisa tobetsa %(optout_ussd)s, hape tobetsa "
+"%(popi_ussd)s."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+"Tjhe! O ke ke wa fumana melaetsa MomConnect ka WhatsApp. Re tla nne re "
+"romele melaetsa MomConnect ka SMS."
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -26,11 +51,3 @@ msgstr ""
 "Re o amohela MomConnect! Ditshebeletso tobetsa %(popi_ussd)s, emisa tobetsa "
 "%(optout_ussd)s (Mahala). Ho fetela WhatsApp, araba “WA”. Tlwaelo SMS "
 "direiti di sebetsa."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Tshwarelo, re ke ke ra romela melaetsa WhatsApp founung ena. Re tla romella "
-"melaetsa MomConnect ka SMS. Ho emisa tobetsa %(optout_ussd)s, hape tobetsa "
-"%(popi_ussd)s."

--- a/locale/ssw_ZA/LC_MESSAGES/django.po
+++ b/locale/ssw_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 16:06+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:33+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ssw_ZA\n"
@@ -17,7 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Ncesi asikhoni kutfumela iWhatsApp kulolucingo. Sitokutfumelela imilayeto "
+"yeMomConnect ngeSMS. Kuyekela shaya %(optout_ussd)s, kutfola leminye shaya "
+"%(popi_ussd)s."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+"Awu nebakitsi! Awukhoni kutfola imilayeto yeMomConnect nge-WhatsApp. "
+"Sitochubeka sikutfumele imilayeto ye-MomConnect nge-SMS."
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -26,11 +51,3 @@ msgstr ""
 "Umukelekile kuMomConnect! Kutfola tinsita letinyenti %(popi_ussd)s, yekela "
 "%(optout_ussd)s (Mahhala). Kuphendvula ngaWhatsApp, phendvula nga'WA'. I-SMS "
 "iyabhadalelwa."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Ncesi asikhoni kutfumela iWhatsApp kulolucingo. Sitokutfumelela imilayeto "
-"yeMomConnect ngeSMS. Kuyekela shaya %(optout_ussd)s, kutfola leminye shaya "
-"%(popi_ussd)s."

--- a/locale/tsn_ZA/LC_MESSAGES/django.po
+++ b/locale/tsn_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 16:07+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:34+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: tsn_ZA\n"
@@ -17,7 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Maswabi, re palelwa ke go romela melaetsa ya WhatsApp mo mogaleng o. Re tla "
+"e romela ka SMS. Go e emisa tobetsa%(optout_ussd)s, go bona dintlha tobetsa"
+"%(popi_ussd)s."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+"Ijooo! O ka se kgone go amogela melaetsa ya MomConnect ka WhatsApp. Re ile "
+"go tswelela go go romela melaetsa ya MomConnect ka SMS."
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -26,11 +51,3 @@ msgstr ""
 "O amogetswe go MomConnect! Ditirelo tobetsa %(popi_ussd)s, go di khutlisa "
 "%(optout_ussd)s (Mahala). WhatsApp, romela lefoko \"WA\". Seelo sa disms se "
 "tla dirisiwa."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Maswabi, re palelwa ke go romela melaetsa ya WhatsApp mo mogaleng o. Re tla "
-"e romela ka SMS. Go e emisa tobetsa%(optout_ussd)s, go bona dintlha tobetsa"
-"%(popi_ussd)s."

--- a/locale/tso_ZA/LC_MESSAGES/django.po
+++ b/locale/tso_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 16:08+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:34+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: tso_ZA\n"
@@ -17,7 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Hi khomele hi nge rhumeli swihungwana swa WA eka foni leyi. MomConnect yi ta "
+"rhumela swihungwana hi SMS. Ku tshika %(optout_ussd)s, ku kuma swotala "
+"%(popi_ussd)s."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+"Yoo, e-e! A wu nge kumi swihungwana swa MomConnect hi WhatsApp. Hi ta tshama "
+"hi ri karhi hi ku rhumela swihungwana swa wena swa MomConnect hi SMS."
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -26,11 +51,3 @@ msgstr ""
 "Ha ku amukela eka MomConnect!Ku kuma vukorhokeri dayila%(popi_ussd)s, ku "
 "tshika dayila%(optout_ussd)s mahala.Kuya eka WhatsApp, hlamula “WA”.Tihakelo "
 "ta SMS ta tirha."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Hi khomele hi nge rhumeli swihungwana swa WA eka foni leyi. MomConnect yi ta "
-"rhumela swihungwana hi SMS. Ku tshika %(optout_ussd)s, ku kuma swotala "
-"%(popi_ussd)s."

--- a/locale/ven_ZA/LC_MESSAGES/django.po
+++ b/locale/ven_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 16:08+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:35+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ven_ZA\n"
@@ -17,7 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Pfarelo, ri nga si kone u rumela milaedza ya WhatsApp kha luṱingo ulwu. Ri "
+"ḓo rumela nga SMS. U bva ndi %(optout_ussd)s, U itela zwinzhi vha lidzele "
+"%(popi_ussd)s."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+"Yoo! Vha nga si kone u wana milaedza ya MomConnect kha WhatsApp. Ri ḓo "
+"dzulela u rumela milaedza yavho ya MomConnect nga SMS."
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -26,11 +51,3 @@ msgstr ""
 "Vho ṱanganedzwa kha MomConnect! Tshumelo vha lidzele%(popi_ussd)s, u imisa "
 "vha lidzele %(optout_ussd)s (Mahala). WhatsApp vha fhindule WA. Hu shuma "
 "mutengo wa SMS."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Pfarelo, ri nga si kone u rumela milaedza ya WhatsApp kha luṱingo ulwu. Ri "
-"ḓo rumela nga SMS. U bva ndi %(optout_ussd)s, U itela zwinzhi vha lidzele "
-"%(popi_ussd)s."

--- a/locale/xho_ZA/LC_MESSAGES/django.po
+++ b/locale/xho_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 16:09+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:35+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: xho_ZA\n"
@@ -17,7 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Uxolo, asikwazi kuthumela WhatsApp imiylz kule fowuni. Siya kuthumela "
+"MomConnect miylz nge-SMS. Ukuyeka dayala %(optout_ussd)s, okunye dayala "
+"%(popi_ussd)s (Mahala)."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+"Owu yhini! Awukwazi kufumana imiyalezo ka-MomConnect ku-WhatsApp. Siya "
+"kuthumelela rhoqo imiyalezo ka-MomConnect nge-SMS."
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -26,11 +51,3 @@ msgstr ""
 "Wamkelekile ku-MomConnect! Ngezinye iinkonzo, cofa u- %(popi_ussd)s, ukuyeka "
 "%(optout_ussd)s (Mahala). Ukuya ku-WhatsApp, yithi “WA”, ngemirhumo "
 "eqhelekileyo ye-SMS."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Uxolo, asikwazi kuthumela WhatsApp imiylz kule fowuni. Siya kuthumela "
-"MomConnect miylz nge-SMS. Ukuyeka dayala %(optout_ussd)s, okunye dayala "
-"%(popi_ussd)s (Mahala)."

--- a/locale/zul_ZA/LC_MESSAGES/django.po
+++ b/locale/zul_ZA/LC_MESSAGES/django.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-08 12:35+0200\n"
-"PO-Revision-Date: 2018-10-02 16:10+0200\n"
+"POT-Creation-Date: 2018-10-05 15:50+0200\n"
+"PO-Revision-Date: 2018-10-05 15:36+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: zul_ZA\n"
@@ -17,7 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: registrations/tasks.py:757
+#: changes/tasks.py:1287
+#, python-format
+msgid ""
+"Sorry but we can't send WhatsApp msgs to this phone. We'll send your "
+"MomConnect msgs on SMS. To stop dial %(optout_ussd)s, for more dial "
+"%(popi_ussd)s (Free)."
+msgstr ""
+"Siyaxolisa asikwazi ukusenda uWhatsApp kule foni. Sizokusendela imiyalezo "
+"yeMomConnect ngeSMS. Ukuphuma dayela %(optout_ussd)s Ukuthola okunye dayela "
+"%(popi_ussd)s."
+
+#: changes/tasks.py:1343
+msgid ""
+"We see that your MomConnect WhatsApp messages are not being delivered. If "
+"you would like to receive your messages over SMS, reply ‘SMS’."
+msgstr ""
+
+#: changes/tasks.py:1404
+msgid ""
+"Oh no! You can't get MomConnect messages on WhatsApp. We'll keep sending "
+"your MomConnect messages on SMS."
+msgstr ""
+"Maye! Awukwazi ukuthola imiyalezo yeMomConnect ngeWhatsApp. Sizoqhubeka "
+"nokuthumela imiyalezo yeMomConnect yakho ngeSMS."
+
+#: registrations/tasks.py:786
 #, python-format
 msgid ""
 "Welcome to MomConnect! For more services dial %(popi_ussd)s, to stop dial "
@@ -26,11 +51,3 @@ msgstr ""
 "Siyakwamukela kuMomConnect! Olunye usizo dayela %(popi_ussd)s, ukuphuma "
 "%(optout_ussd)s (Mahhala). Ukuya kuWhatsApp, ithi \"WA\". Kusebenza amanani "
 "ajwayelekile eSMS."
-
-msgid ""
-"Sorry, we can't send WhatsApp msgs to this phone. We'll send your MomConnect "
-"msgs on SMS. To stop dial %(optout_ussd)s, for more dial %(popi_ussd)s."
-msgstr ""
-"Siyaxolisa asikwazi ukusenda uWhatsApp kule foni. Sizokusendela imiyalezo "
-"yeMomConnect ngeSMS. Ukuphuma dayela %(optout_ussd)s Ukuthola okunye dayela "
-"%(popi_ussd)s."


### PR DESCRIPTION
This PR adds a view to receive webhook events from the Seed Message Sender that were added in https://github.com/praekelt/seed-message-sender/pull/96

It currently supports the whatsapp contact check failure event.