### PR TITLE
Fix service info subscription request function

### DIFF
--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -319,7 +319,10 @@ class ValidateSubscribe(Task):
         Creates a new subscription request for the service info message set.
         This should only be created for momconnect whatsapp registrations.
         """
-        if registration.reg_type != "whatsapp_prebirth":
+        if (
+            registration.reg_type != "whatsapp_prebirth"
+            or registration.source.authority in ["hw_partial", "patient"]
+        ):
             return
 
         self.log.info("Fetching messageset")

--- a/registrations/test_tasks.py
+++ b/registrations/test_tasks.py
@@ -1110,6 +1110,17 @@ class ServiceInfoSubscriptionRequestTestCase(AuthenticatedAPITestCase):
         validate_subscribe.create_service_info_subscriptionrequest(registration)
         self.assertEqual(SubscriptionRequest.objects.count(), 0)
 
+    def test_skips_other_authorities(self):
+        """
+        Should skip creating subscription requests if the source authority is
+        partial or public
+        """
+        registration = Registration(
+            source=self.make_source_partialuser(), reg_type="whatsapp_prebirth"
+        )
+        validate_subscribe.create_service_info_subscriptionrequest(registration)
+        self.assertEqual(SubscriptionRequest.objects.count(), 0)
+
     @responses.activate
     def test_creates_subscriptionrequest(self):
         """


### PR DESCRIPTION
The `create_service_info_subscriptionrequest` function is currently trying to create a service info subscription for public registrations where there is no 'edd' field and causing a sentry error.