### PR TITLE
No sms messageset notification

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -577,9 +577,7 @@ class ValidateImplement(Task):
                 if "service_info" in short_name:
                     continue
 
-                messageset = messagesets_rev.get(re.sub("^whatsapp_", "", short_name))
-
-                if not messageset:
+                if short_name == "whatsapp_momconnect_postbirth.hw_full.3":
                     text = (
                         "We notice that you have been receiving MomConnect msgs on "
                         "WhatsApp for children between 1 - 2. Messages for children "
@@ -602,6 +600,7 @@ class ValidateImplement(Task):
 
                 # Change any WhatsApp subscriptions to SMS
                 sbm_client.update_subscription(sub["id"], {"active": False})
+                messageset = messagesets_rev[re.sub("^whatsapp_", "", short_name)]
 
                 SubscriptionRequest.objects.create(
                     identity=sub["identity"],

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -590,7 +590,7 @@ class ValidateImplement(Task):
                         {
                             "to_identity": change.registrant_id,
                             "content": text,
-                            "channel": "JUNE_TEXT",
+                            "channel": "WHATSAPP",
                             "metadata": {},
                         }
                     )

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -573,10 +573,6 @@ class ValidateImplement(Task):
 
             elif change.data["channel"] == "sms" and "whatsapp" in short_name:
 
-                # There's no service info for SMS
-                if "service_info" in short_name:
-                    continue
-
                 if short_name == "whatsapp_momconnect_postbirth.hw_full.3":
                     text = (
                         "We notice that you have been receiving MomConnect msgs on "
@@ -602,6 +598,11 @@ class ValidateImplement(Task):
 
                 # Change any WhatsApp subscriptions to SMS
                 sbm_client.update_subscription(sub["id"], {"active": False})
+
+                # There's no service info for SMS
+                if "service_info" in short_name:
+                    continue
+
                 messageset = messagesets_rev[re.sub("^whatsapp_", "", short_name)]
 
                 SubscriptionRequest.objects.create(

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -594,7 +594,9 @@ class ValidateImplement(Task):
                             "metadata": {},
                         }
                     )
-                    change.data["error"] = "No whatsapp available"
+                    change.data[
+                        "error"
+                    ] = "WhatsApp-only messagesets cannot be switched to SMS"
                     change.save()
                     return
 

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -3850,7 +3850,9 @@ class TestChangeActions(AuthenticatedAPITestCase):
         validate_implement(change.id)
         change.refresh_from_db()
         self.assertTrue(change.validated)
-        self.assertTrue(change.data["error"], "No whatsapp available")
+        self.assertTrue(
+            change.data["error"], "WhatsApp-only messagesets cannot be switched to SMS"
+        )
 
         self.assertEqual(SubscriptionRequest.objects.all().count(), 0)
 

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from unittest import mock
 
 import responses
 from django.contrib.auth.models import User
@@ -3803,6 +3804,69 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 "channel_current": "whatsapp",
                 "channel_new": change.data["channel"],
             },
+        )
+
+    @mock.patch("changes.tasks.utils.ms_client.create_outbound")
+    @responses.activate
+    def test_switch_channel_to_sms_not_available(self, mock_create_outbound):
+        """
+        Switching to SMS where there is no corrosponding WHatsapp set should
+        not change the subscription to sms and should send a notification to
+        the user.
+        """
+        registrant_id = "mother01-63e2-4acc-9b94-26663b9bc267"
+        mock_get_messagesets(
+            ["whatsapp_momconnect_prebirth", "not_momconnect_prebirth"]
+        )
+        mock_get_subscriptions(
+            "?identity={}&active=True".format(registrant_id),
+            [
+                {
+                    "id": "sub1",
+                    "messageset": 0,
+                    "identity": registrant_id,
+                    "next_sequence_number": 7,
+                    "lang": "eng",
+                    "schedule": 2,
+                    "active": True,
+                },
+                {"messageset": 1, "active": True},
+            ],
+        )
+
+        # . mock get identity by id
+        utils_tests.mock_get_identity_by_id(
+            "mother01-63e2-4acc-9b94-26663b9bc267",
+            {"addresses": {"msisdn": {"+27821112222": {}}}},
+        )
+
+        change = Change.objects.create(
+            registrant_id=registrant_id,
+            action="switch_channel",
+            data={"channel": "sms"},
+            source=self.make_source_normaluser(),
+        )
+
+        validate_implement(change.id)
+        change.refresh_from_db()
+        self.assertTrue(change.validated)
+        self.assertTrue(change.data["error"], "No whatsapp available")
+
+        self.assertEqual(SubscriptionRequest.objects.all().count(), 0)
+
+        mock_create_outbound.assert_called_once_with(
+            {
+                "to_identity": "mother01-63e2-4acc-9b94-26663b9bc267",
+                "content": (
+                    "We notice that you have been receiving MomConnect msgs on "
+                    "WhatsApp for children between 1 - 2. Messages for children "
+                    "between 1 - 2 are only available on WhatsApp - switching to "
+                    "SMS means you will not receive any messages. You can stop "
+                    "your MomConnect messages completely by replying ‘STOP‘"
+                ),
+                "channel": "JUNE_TEXT",
+                "metadata": {},
+            }
         )
 
     @responses.activate

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -3816,7 +3816,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         """
         registrant_id = "mother01-63e2-4acc-9b94-26663b9bc267"
         mock_get_messagesets(
-            ["whatsapp_momconnect_prebirth", "not_momconnect_prebirth"]
+            ["whatsapp_momconnect_postbirth.hw_full.3", "not_momconnect_prebirth"]
         )
         mock_get_subscriptions(
             "?identity={}&active=True".format(registrant_id),

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -3864,7 +3864,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
                     "SMS means you will not receive any messages. You can stop "
                     "your MomConnect messages completely by replying ‘STOP‘"
                 ),
-                "channel": "JUNE_TEXT",
+                "channel": "WHATSAPP",
                 "metadata": {},
             }
         )


### PR DESCRIPTION
Mom who is on 1-2 Message Set (WA) and tries to switch herself to SMS will get the following autoresponse: _“We notice that you have been receiving MomConnect msgs on WhatsApp for children between 1 - 2. Messages for children between 1 - 2 are only available on WhatsApp - switching to SMS means you will not receive any messages. You can stop your MomConnect messages completely by replying “STOP”._ *NB: The system MUST NOT switch the mom to SMS, she can either stay on WA or initiate an opt out herself.*