### PR TITLE
Send engage helpdesk replies to DHIS2

### DIFF
--- a/changes/serializers.py
+++ b/changes/serializers.py
@@ -89,10 +89,14 @@ class ReceiveEngageMessage(serializers.Serializer):
     # We're only interested in text messages
     type = serializers.ChoiceField(["text"])
 
-    # We're only interested in messages sent from Engage UI
     class Vnd(serializers.Serializer):
         class V1(serializers.Serializer):
-            author = serializers.CharField(required=True)
+            class Author(serializers.Serializer):
+                name = serializers.CharField(required=True)
+                # We're only interested in messages sent from Engage UI
+                type = serializers.ChoiceField(["OPERATOR"])
+
+            author = Author()
 
         v1 = V1()
 

--- a/changes/serializers.py
+++ b/changes/serializers.py
@@ -84,6 +84,21 @@ class ReceiveWhatsAppEventSerializer(serializers.Serializer):
         return super(ReceiveWhatsAppEventSerializer, self).to_internal_value(data)
 
 
+class ReceiveEngageMessage(serializers.Serializer):
+    to = serializers.CharField(required=True)
+    # We're only interested in text messages
+    type = serializers.ChoiceField(["text"])
+
+    # We're only interested in messages sent from Engage UI
+    class Vnd(serializers.Serializer):
+        class V1(serializers.Serializer):
+            author = serializers.CharField(required=True)
+
+        v1 = V1()
+
+    _vnd = Vnd()
+
+
 class ReceiveWhatsAppSystemEventSerializer(serializers.Serializer):
     class EventSerializer(serializers.Serializer):
         type = serializers.CharField(required=True)

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1455,3 +1455,8 @@ class ProcessWhatsAppContactCheckFail(Task):
 
 
 process_whatsapp_contact_check_fail = ProcessWhatsAppContactCheckFail()
+
+
+def process_engage_helpdesk_outbound(wa_contact, message_id):
+    # TODO: Implement
+    pass

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1490,6 +1490,7 @@ def get_engage_inbound_and_reply(wa_contact_id, message_id):
             inbound_address: The contact address of the inbound
             reply_text: The text of the outbound
             reply_timestamp: The timestamp of the outbound
+            reply_operator: The operator who sent the outbound
     """
 
     response = requests.get(
@@ -1505,7 +1506,7 @@ def get_engage_inbound_and_reply(wa_contact_id, message_id):
     # Filter out outbounds that aren't from helpdesk operators
     messages = filter(
         lambda m: m["_vnd"]["v1"]["direction"] == "inbound"
-        or m["_vnd"]["v1"].get("author"),
+        or m["_vnd"]["v1"]["author"]["type"] == "OPERATOR",
         messages,
     )
     # Sort in timestamp order, descending
@@ -1520,7 +1521,7 @@ def get_engage_inbound_and_reply(wa_contact_id, message_id):
     # For text messages, message is in "body", for media, it's in "caption"
     reply_text = reply_text.get("body") or reply_text.get("caption")
     reply_timestamp = reply["timestamp"]
-    reply_operator = reply["_vnd"]["v1"]["author"]
+    reply_operator = reply["_vnd"]["v1"]["author"]["name"]
 
     # Remove all outbound from beginning now that we have the one we care about
     messages = dropwhile(lambda m: m["_vnd"]["v1"]["direction"] == "outbound", messages)

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1556,7 +1556,7 @@ def get_identity_from_msisdn(context, field):
     """
     Fetches the identity from the identity store using `field` inside the context and
     returns its ID in the context
-    
+
     Args:
         context (dict): The context to find the msisdn and add the ID in
         field (str): The field in the context that contains the MSISDN

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -406,7 +406,11 @@ class GetEngageInboundAndReplyTests(TestCase):
                             "v1": {
                                 "direction": "outbound",
                                 "in_reply_to": "KCGGK3FVGUV_CiD9cD-KZ7S6UsB76FeJP3sc",
-                                "author": 2,
+                                "author": {
+                                    "id": 2,
+                                    "name": "Operator Name",
+                                    "type": "OPERATOR",
+                                },
                             }
                         },
                         "from": "27820001002",
@@ -420,7 +424,11 @@ class GetEngageInboundAndReplyTests(TestCase):
                             "v1": {
                                 "direction": "outbound",
                                 "in_reply_to": "gBGGJ3EVEUV_AgkC5c71UQ9ug08",
-                                "author": 2,
+                                "author": {
+                                    "id": 2,
+                                    "name": "Operator Name",
+                                    "type": "OPERATOR",
+                                },
                             }
                         },
                         "from": "27820001002",
@@ -434,6 +442,11 @@ class GetEngageInboundAndReplyTests(TestCase):
                             "v1": {
                                 "direction": "outbound",
                                 "in_reply_to": "ABGGJ3EVEUV_AhC9cG-UA8S5UsB75FeJP1sb",
+                                "author": {
+                                    "id": 7,
+                                    "name": "Autoresponse Name",
+                                    "type": "SYSTEM",
+                                },
                             }
                         },
                         "from": "27820001002",
@@ -469,7 +482,11 @@ class GetEngageInboundAndReplyTests(TestCase):
                             "v1": {
                                 "direction": "outbound",
                                 "in_reply_to": "BCGGJ3FVFUV_CiC9cG-KZ7S5UsB73FeJP2sc",
-                                "author": 2,
+                                "author": {
+                                    "id": 2,
+                                    "name": "Operator Name",
+                                    "type": "OPERATOR",
+                                },
                             }
                         },
                         "from": "27820001002",
@@ -498,7 +515,7 @@ class GetEngageInboundAndReplyTests(TestCase):
                 "inbound_timestamp": "1540803293",
                 "reply_text": "Operator response",
                 "reply_timestamp": "1540803363",
-                "reply_operator": 2,
+                "reply_operator": "Operator Name",
             },
         )
 
@@ -528,7 +545,7 @@ class SendHelpdeskResponseToDHIS2Tests(DisconnectRegistrationSignalsMixin, TestC
                     },
                     "class": "Unclassified",
                     "type": 7,
-                    "op": "2",
+                    "op": "Operator Name",
                 },
             )
             return (200, {}, json.dumps({}))
@@ -553,7 +570,7 @@ class SendHelpdeskResponseToDHIS2Tests(DisconnectRegistrationSignalsMixin, TestC
                 "inbound_address": "27820001001",
                 "reply_text": "Operator answer",
                 "reply_timestamp": "1540803363",
-                "reply_operator": 2,
+                "reply_operator": "Operator Name",
                 "identity_id": "identity-uuid",
             }
         ).get()
@@ -602,7 +619,11 @@ class ProcessEngageHelpdeskOutboundTests(DisconnectRegistrationSignalsMixin, Tes
                             "v1": {
                                 "direction": "outbound",
                                 "in_reply_to": "gBGGJ3EVEUV_AgkC5c71UQ9ug08",
-                                "author": 2,
+                                "author": {
+                                    "id": 2,
+                                    "name": "Operator Name",
+                                    "type": "OPERATOR",
+                                },
                             }
                         },
                         "from": "27820001002",
@@ -647,7 +668,7 @@ class ProcessEngageHelpdeskOutboundTests(DisconnectRegistrationSignalsMixin, Tes
                     },
                     "class": "Unclassified",
                     "type": 7,
-                    "op": "2",
+                    "op": "Operator Name",
                 },
             )
             return (200, {}, json.dumps({}))

--- a/changes/test_views.py
+++ b/changes/test_views.py
@@ -125,7 +125,13 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
             "type": "text",
             "text": {"body": "Helpdesk operator to mother"},
             "timestamp": "1540982581",
-            "_vnd": {"v1": {"direction": "outbound", "in_reply_to": None, "author": 2}},
+            "_vnd": {
+                "v1": {
+                    "direction": "outbound",
+                    "in_reply_to": None,
+                    "author": {"id": 2, "name": "Operator Name", "type": "OPERATOR"},
+                }
+            },
         }
 
         response = self.client.post(
@@ -171,7 +177,13 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
             "type": "text",
             "text": {"body": "Helpdesk operator to mother"},
             "timestamp": "1540982581",
-            "_vnd": {"v1": {"direction": "outbound", "in_reply_to": None, "author": 2}},
+            "_vnd": {
+                "v1": {
+                    "direction": "outbound",
+                    "in_reply_to": None,
+                    "author": {"id": 2, "name": "Operator Name", "type": "OPERATOR"},
+                }
+            },
         }
         response = self.client.post(
             url, webhook, format="json", HTTP_X_ENGAGE_HOOK_SUBSCRIPTION="engage"

--- a/changes/test_views.py
+++ b/changes/test_views.py
@@ -194,7 +194,7 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
             "to": "27820001001",
             "type": "text",
             "text": {"body": "Helpdesk operator to mother"},
-            "timestamp": "1540982581"
+            "timestamp": "1540982581",
         }
 
         response = self.client.post(
@@ -206,6 +206,7 @@ class ReceiveWhatsAppEventViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
 
 @mock.patch("changes.views.ReceiveWhatsAppBase.validate_signature")
 @mock.patch("changes.views.tasks.process_whatsapp_system_event")

--- a/changes/views.py
+++ b/changes/views.py
@@ -25,10 +25,10 @@ from .serializers import (
     AdminChangeSerializer,
     AdminOptoutSerializer,
     ChangeSerializer,
+    ReceiveEngageMessage,
     ReceiveWhatsAppEventSerializer,
     ReceiveWhatsAppSystemEventSerializer,
     SeedMessageSenderHookSerializer,
-    ReceiveEngageMessage,
 )
 
 


### PR DESCRIPTION
This PR modifies the engage webhook view to also accept outbound + filter outbound messages, and adds tasks to process this information and send the relevant information to OpenHIM to be placed in DHIS2.

This relies on the `author` field on the engage API, which has not yet been implemented.