### PR TITLE
Management command for TeenMomConnect post birth subscriptions

### DIFF
--- a/registrations/management/commands/teenmomconnect_postbirth_subscriptions.py
+++ b/registrations/management/commands/teenmomconnect_postbirth_subscriptions.py
@@ -1,0 +1,70 @@
+from collections import namedtuple
+from django.core.management.base import BaseCommand, CommandError
+from openpyxl import load_workbook
+
+
+Contact = namedtuple("Contact", ["msisdn", "language"])
+
+
+class Command(BaseCommand):
+    help = (
+        "Creates post birth subscriptions for the mothers specified in the xlsx file. "
+        "Doesn't create duplicate subscriptions for mothers that already have a "
+        "postbirth subscription"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("file_path", type=str, help="The path to the xlsx file")
+
+    @staticmethod
+    def extract_contacts_from_workbook(file_path):
+        """
+        Extracts the list of Contacts from the workbook at `file_path`, raising a
+        CommandError if there are any issues with the workbook's format
+        """
+        workbook = load_workbook(file_path, read_only=True)
+
+        try:
+            [worksheet] = workbook.worksheets
+        except ValueError:
+            raise CommandError("Document can only have a single sheet")
+
+        try:
+            [phone_header] = filter(lambda r: r.value == "Phone", worksheet[1])
+        except (ValueError, IndexError):
+            raise CommandError("Sheet must have a single 'Phone' column header")
+        try:
+            [language_header] = filter(lambda r: r.value == "Language", worksheet[1])
+        except (ValueError, IndexError):
+            raise CommandError("Sheet must have a single 'Language' column header")
+
+        for row in worksheet.iter_rows(min_row=2):
+            yield Contact(
+                row[phone_header.column - 1].value,
+                row[language_header.column - 1].value,
+            )
+
+    @staticmethod
+    def validate_msisdn(msisdn):
+        """
+        Returns an E164 internationally formatted msisdn string if valid, else logs an
+        error and returns `None`
+        """
+
+    @staticmethod
+    def create_or_get_identity(msisdn):
+        """
+        Fetches the identity with the given msisdn, or if identity doesn't exist,
+        creates and returns it.
+        """
+
+    @staticmethod
+    def create_subscription(identity, messageset):
+        """
+        Creates a subscription to `messageset` for `identity` if such a subscription
+        does not yet exist.
+        """
+
+    def handle(self, *args, **options):
+        contacts = self.extract_contacts_from_workbook(options["file_path"])
+        print(list(contacts))

--- a/registrations/management/commands/tests/test_teenmomconnect_postbirth_subscriptions.py
+++ b/registrations/management/commands/tests/test_teenmomconnect_postbirth_subscriptions.py
@@ -153,3 +153,33 @@ class TeenMomConnectPostbirthSubscriptionsCommandTests(TestCase):
         self.assertIn(
             "Invalid phone number +12001230101. Skipping...", command.stdout.getvalue()
         )
+
+    def test_validate_language(self):
+        """
+        If the language code is valid, it should be returned in the Seed language format
+        """
+        command = Command()
+        self.assertEqual(command.validate_language("eng"), "eng_ZA")
+
+    def test_validate_language_invalid(self):
+        """
+        If the language code is invalid, an error should be logged and None returned
+        """
+        command = Command()
+        command.stdout = io.StringIO()
+        self.assertEqual(command.validate_language("foo"), None)
+        self.assertIn(
+            "Invalid language code foo. Skipping...", command.stdout.getvalue()
+        )
+
+    def test_validate_language_not_in_seed(self):
+        """
+        If the language code is not in the project's list of languages, an error should
+        be logged and None returned
+        """
+        command = Command()
+        command.stdout = io.StringIO()
+        self.assertEqual(command.validate_language("arg"), None)
+        self.assertIn(
+            "Invalid language code arg. Skipping...", command.stdout.getvalue()
+        )

--- a/registrations/management/commands/tests/test_teenmomconnect_postbirth_subscriptions.py
+++ b/registrations/management/commands/tests/test_teenmomconnect_postbirth_subscriptions.py
@@ -3,8 +3,8 @@ import random
 import string
 import tempfile
 import uuid
-from urllib.parse import urlencode
 from unittest.mock import call, patch
+from urllib.parse import urlencode
 
 import responses
 from django.core.management import call_command
@@ -348,6 +348,7 @@ class TeenMomConnectPostbirthSubscriptionsCommandTests(TestCase):
         Running the command should filter out bad rows, properly format the data of the
         rest, and create identities and subscriptions for them.
         """
+
         def identity_side_effect(msisdn, lang):
             return {"msisdn": msisdn, "lang": lang}
 

--- a/registrations/management/commands/tests/test_teenmomconnect_postbirth_subscriptions.py
+++ b/registrations/management/commands/tests/test_teenmomconnect_postbirth_subscriptions.py
@@ -1,0 +1,111 @@
+import random
+import tempfile
+import string
+import uuid
+
+from django.core.management.base import CommandError
+from django.test import TestCase
+from openpyxl import Workbook
+
+from registrations.management.commands.teenmomconnect_postbirth_subscriptions import (
+    Contact,
+    Command,
+)
+
+
+def randomword(length):
+    """Returns a random string of ascii letters of length `length`"""
+    return "".join(random.choice(string.ascii_letters) for _ in range(length))
+
+
+class TeenMomConnectPostbirthSubscriptionsCommandTests(TestCase):
+    @classmethod
+    def generate_workbook(cls, contacts):
+        """
+        Generates a workbook with the specified `contacts`. Returns the file handler
+        of the file where the workbook is stored
+        """
+        workbook = Workbook(write_only=True)
+        worksheet = workbook.create_sheet()
+        worksheet.append(["Contact UUID", "Name", "Language", "Phone", "Random"])
+        for c in contacts:
+            worksheet.append(
+                [
+                    str(uuid.uuid4()),
+                    randomword(10),
+                    c.language,
+                    c.msisdn,
+                    randomword(10),
+                ]
+            )
+
+        f = tempfile.NamedTemporaryFile(suffix=".xlsx")
+        workbook.save(f.name)
+        return f
+
+    def test_extract_contacts_from_workbook(self):
+        """
+        If the workbook is valid, an iterable of Contacts should be returned.
+        """
+        contacts = [Contact("+27820001001", "eng"), Contact("+27820001002", "xho")]
+        f = self.generate_workbook(contacts)
+        extracted_contacts = Command.extract_contacts_from_workbook(f.name)
+        self.assertEqual(list(extracted_contacts), contacts)
+
+    def test_extract_contacts_from_workbook_multiple_sheets(self):
+        """
+        If there is more than one sheet in the workbook, then a CommandError should
+        be raised
+        """
+        workbook = Workbook(write_only=True)
+        for _ in range(2):
+            workbook.create_sheet()
+        f = tempfile.NamedTemporaryFile(suffix=".xlsx")
+        workbook.save(f.name)
+        with self.assertRaises(CommandError) as e:
+            list(Command.extract_contacts_from_workbook(f.name))
+        self.assertIn("Document can only have a single sheet", str(e.exception))
+
+    def test_extract_contacts_from_workbook_no_phone_header(self):
+        """
+        If there is no `Phone` header field, then a CommandError should be raised
+        """
+        workbook = Workbook(write_only=True)
+        worksheet = workbook.create_sheet()
+        worksheet.append(["Contact UUID", "Name", "Language", "Random"])
+        f = tempfile.NamedTemporaryFile(suffix=".xlsx")
+        workbook.save(f.name)
+        with self.assertRaises(CommandError) as e:
+            list(Command.extract_contacts_from_workbook(f.name))
+        self.assertIn(
+            "Sheet must have a single 'Phone' column header", str(e.exception)
+        )
+
+    def test_extract_contacts_from_workbook_no_language_header(self):
+        """
+        If there is no `Phone` header field, then a CommandError should be raised
+        """
+        workbook = Workbook(write_only=True)
+        worksheet = workbook.create_sheet()
+        worksheet.append(["Contact UUID", "Name", "Phone", "Random"])
+        f = tempfile.NamedTemporaryFile(suffix=".xlsx")
+        workbook.save(f.name)
+        with self.assertRaises(CommandError) as e:
+            list(Command.extract_contacts_from_workbook(f.name))
+        self.assertIn(
+            "Sheet must have a single 'Language' column header", str(e.exception)
+        )
+
+    def test_extract_contacts_from_workbook_no_header(self):
+        """
+        If there is no header field, then a CommandError should be raised
+        """
+        workbook = Workbook(write_only=True)
+        workbook.create_sheet()
+        f = tempfile.NamedTemporaryFile(suffix=".xlsx")
+        workbook.save(f.name)
+        with self.assertRaises(CommandError) as e:
+            list(Command.extract_contacts_from_workbook(f.name))
+        self.assertIn(
+            "Sheet must have a single 'Phone' column header", str(e.exception)
+        )

--- a/registrations/management/commands/tests/test_teenmomconnect_postbirth_subscriptions.py
+++ b/registrations/management/commands/tests/test_teenmomconnect_postbirth_subscriptions.py
@@ -1,3 +1,4 @@
+import io
 import random
 import tempfile
 import string
@@ -108,4 +109,47 @@ class TeenMomConnectPostbirthSubscriptionsCommandTests(TestCase):
             list(Command.extract_contacts_from_workbook(f.name))
         self.assertIn(
             "Sheet must have a single 'Phone' column header", str(e.exception)
+        )
+
+    def test_validate_msisdn(self):
+        """
+        If the msisdn is valid, it should be returned in E164 international format
+        """
+        command = Command()
+        self.assertEqual(command.validate_msisdn("0820001001"), "+27820001001")
+
+    def test_validate_msisdn_not_parsable(self):
+        """
+        If it's not a parsable msisdn, an error should be logged and `None` should be
+        returned
+        """
+        command = Command()
+        command.stdout = io.StringIO()
+        self.assertEqual(command.validate_msisdn("gibberish"), None)
+        self.assertIn(
+            "Invalid phone number gibberish. Skipping...", command.stdout.getvalue()
+        )
+
+    def test_validate_msisdn_not_possible(self):
+        """
+        If it's not a possible msisdn, an error should be logged and `None` should be
+        returned
+        """
+        command = Command()
+        command.stdout = io.StringIO()
+        self.assertEqual(command.validate_msisdn("+1200012301"), None)
+        self.assertIn(
+            "Invalid phone number +1200012301. Skipping...", command.stdout.getvalue()
+        )
+
+    def test_validate_msisdn_not_valid(self):
+        """
+        If it's not a valid msisdn, an error should be logged and `None` should be
+        returned
+        """
+        command = Command()
+        command.stdout = io.StringIO()
+        self.assertEqual(command.validate_msisdn("+12001230101"), None)
+        self.assertIn(
+            "Invalid phone number +12001230101. Skipping...", command.stdout.getvalue()
         )

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "channels_redis==2.1.0",
         "django-simple-history==2.4.0",
         "openpyxl==2.5.9",
+        "iso-639==0.4.5",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "channels==2.1.3",
         "channels_redis==2.1.0",
         "django-simple-history==2.4.0",
+        "openpyxl==2.5.9",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This PR adds a management command that takes an xlsx document, which is an export from RapidPro, and creates subscriptions to the post birth messageset for those mothers.

It has protection against invalid values for any of the fields that we require, and it won't create a subscription if the mother already has an active subscription, making it idempotent