### PR TITLE
Ensure that operator field is a string that contains an integer

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1663,7 +1663,7 @@ def send_helpdesk_response_to_dhis2(context):
             },
             "class": ",".join(context["inbound_labels"]) or "Unclassified",
             "type": 7,  # Helpdesk
-            "op": context["reply_operator"],
+            "op": str(context["reply_operator"]),
         },
     )
     result.raise_for_status()

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -568,7 +568,7 @@ class SendHelpdeskResponseToDHIS2Tests(DisconnectRegistrationSignalsMixin, TestC
                     },
                     "class": "label1,label2",
                     "type": 7,
-                    "op": 104296490747485586223672247128147036730,
+                    "op": "104296490747485586223672247128147036730",
                 },
             )
             return (200, {}, json.dumps({}))
@@ -705,7 +705,7 @@ class ProcessEngageHelpdeskOutboundTests(DisconnectRegistrationSignalsMixin, Tes
                     },
                     "class": "test",
                     "type": 7,
-                    "op": 56748517727534413379787391391214157498,
+                    "op": "56748517727534413379787391391214157498",
                 },
             )
             return (200, {}, json.dumps({}))


### PR DESCRIPTION
So even though Jembi want us to send an integer, their validation is for a string. So we need to send a string whose contents are an integer for them to accept it