### PR TITLE
Feature/momza 1044 add wa message expiry event

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1,7 +1,7 @@
 import json
 import re
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from itertools import chain as ichain
 from itertools import dropwhile, takewhile
 from uuid import UUID

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1498,8 +1498,9 @@ class ProcessWhatsAppTimeoutSystemEvent(Task):
             }
         )
 
-    def run(self, vumi_message_id: str, timestamp: int, event_type: str,
-            **kwargs) -> None:
+    def run(
+        self, vumi_message_id: str, timestamp: int, event_type: str, **kwargs
+    ) -> None:
         try:
             identity_uuid: str = next(
                 utils.ms_client.get_outbounds({"vumi_message_id": vumi_message_id})[
@@ -1515,12 +1516,12 @@ class ProcessWhatsAppTimeoutSystemEvent(Task):
         if event_type == "undelivered":
             d1 = datetime.fromtimestamp(timestamp)
             d2 = datetime.today()
-            week1 = (d1 - timedelta(days=d1.weekday()))
-            week2 = (d2 - timedelta(days=d2.weekday()))
+            week1 = d1 - timedelta(days=d1.weekday())
+            week2 = d2 - timedelta(days=d2.weekday())
             # Returns 0 if both dates fall withing one week, 1 if on two weeks etc.
             weeks = int(round((week2 - week1).days / 7))
             months = int(round((week2 - week1).days / 30))
-            if (weeks == 1 and months == 0):
+            if weeks == 1 and months == 0:
                 self.handle_undelivered(identity_uuid)
 
 

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1522,7 +1522,7 @@ class ProcessWhatsAppTimeoutSystemEvent(Task):
             if timeout_timestamp is None:
                 self.handle_undelivered(identity_uuid)
             else:
-                d1 = datetime.strptime(timeout_timestamp, "%d/%m/%Y")
+                d1 = datetime.fromtimestamp(timeout_timestamp)
                 d2 = datetime.today()
                 week1 = d1 - timedelta(days=d1.weekday())
                 week2 = d2 - timedelta(days=d2.weekday())

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1,7 +1,7 @@
-import time
-from datetime import datetime, timedelta
 import json
 import re
+import time
+from datetime import datetime, timedelta
 from itertools import chain as ichain
 from itertools import dropwhile, takewhile
 from uuid import UUID

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -6,6 +6,7 @@ from itertools import dropwhile, takewhile
 from uuid import UUID
 
 import phonenumbers
+import pytz
 import requests
 from celery import chain
 from celery.task import Task
@@ -1621,15 +1622,13 @@ def get_text_or_caption_from_turn_message(message: dict) -> str:
     return message["image"]["caption"]
 
 
-def get_timestamp_from_turn_message(message: dict) -> datetime.datetime:
+def get_timestamp_from_turn_message(message: dict) -> datetime:
     """
     Gets the timestamp from a turn message, returns it as a timezone aware datetime
     object.
     """
     try:
-        return datetime.datetime.fromtimestamp(
-            int(message["timestamp"]), tz=datetime.timezone.utc
-        )
+        return datetime.fromtimestamp(int(message["timestamp"]), tz=pytz.utc)
     except TypeError:
         return dateparse.parse_datetime(message["_vnd"]["v1"]["inserted_at"])
 

--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1,6 +1,5 @@
 import json
 import re
-import time
 from datetime import datetime
 from itertools import chain as ichain
 from itertools import dropwhile, takewhile

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -355,8 +355,9 @@ class ProcessWhatsAppSystemEventTaskTests(WhatsAppBaseTestCase):
         date = (datetime.now() + timedelta(days=7)).strftime("%d/%m/%Y")
         last_timeout = (datetime.now() - timedelta(days=14)).strftime("%d/%m/%Y")
         timestamp = time.mktime(datetime.strptime(date, "%d/%m/%Y").timetuple())
-        timeout_timestamp = time.mktime(datetime.strptime(last_timeout,
-                                                          "%d/%m/%Y").timetuple())
+        timeout_timestamp = time.mktime(
+            datetime.strptime(last_timeout, "%d/%m/%Y").timetuple()
+        )
 
         process_whatsapp_timeout_system_event(
             "messageid", timestamp, "undelivered", timeout_timestamp

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -353,8 +353,10 @@ class ProcessWhatsAppSystemEventTaskTests(WhatsAppBaseTestCase):
         self.create_identity_lookup()
 
         date = (datetime.now() + timedelta(days=7)).strftime("%d/%m/%Y")
+        last_timeout = (datetime.now() - timedelta(days=14)).strftime("%d/%m/%Y")
         timestamp = time.mktime(datetime.strptime(date, "%d/%m/%Y").timetuple())
-        timeout_timestamp = (datetime.now() - timedelta(days=14)).strftime("%d/%m/%Y")
+        timeout_timestamp = time.mktime(datetime.strptime(last_timeout,
+                                                          "%d/%m/%Y").timetuple())
 
         process_whatsapp_timeout_system_event(
             "messageid", timestamp, "undelivered", timeout_timestamp

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -82,30 +82,13 @@ class WhatsAppBaseTestCase(TestCase):
             match_querystring=True,
         )
 
-    def create_identity_lookup_with_id_field(self, lang="eng_ZA"):
-        responses.add(
-            responses.GET,
-            "http://is/api/v1/identities/test-identity-uuid/",
-            json={
-                "results": [
-                    {"id": "test_identity-uuid", "details": {"lang_code": lang}}
-                ]
-            },
-            status=200,
-            match_querystring=True,
-        )
-
-    def update_identity_lookup_with_id_field(self, lang="eng_ZA"):
+    def update_identity_lookup(self, lang="eng_ZA"):
         responses.add(
             responses.PATCH,
             "http://is/api/v1/identities/test-identity-uuid/",
             json={
-                "results": [
-                    {
-                        "id": "test_identity-uuid",
-                        "details": {"lang_code": lang, "timeout_timestamp": "time"},
-                    }
-                ]
+                "id": "test_identity-uuid",
+                "details": {"lang_code": lang, "timeout_timestamp": "time"},
             },
             status=200,
             match_querystring=True,
@@ -115,7 +98,7 @@ class WhatsAppBaseTestCase(TestCase):
         responses.add(
             responses.GET,
             "http://is/api/v1/identities/test-identity-uuid/",
-            json={"identity": "result", "details": {"lang_code": lang}},
+            json={"id": "test_identity-uuid", "details": {"lang_code": lang}},
             status=200,
             match_querystring=True,
         )
@@ -125,15 +108,8 @@ class WhatsAppBaseTestCase(TestCase):
             responses.GET,
             "http://is/api/v1/identities/test-identity-uuid/",
             json={
-                "results": [
-                    {
-                        "id": "test_identity-uuid",
-                        "details": {
-                            "lang_code": "eng_ZA",
-                            "timeout_timestamp": timestamp,
-                        },
-                    }
-                ]
+                "id": "test_identity-uuid",
+                "details": {"lang_code": "eng_ZA", "timeout_timestamp": timestamp},
             },
             status=200,
             match_querystring=True,
@@ -376,8 +352,8 @@ class ProcessWhatsAppSystemEventTaskTests(WhatsAppBaseTestCase):
         source = Source.objects.create(user=user)
 
         self.create_outbound_lookup()
-        self.create_identity_lookup_with_id_field()
-        self.update_identity_lookup_with_id_field()
+        self.create_identity_lookup()
+        self.update_identity_lookup()
 
         timestamp = 1543999390.069308
         mock_get_utc_now.return_value = datetime.fromtimestamp(timestamp)
@@ -400,10 +376,8 @@ class ProcessWhatsAppSystemEventTaskTests(WhatsAppBaseTestCase):
         )
 
         mock_update_identiity.assert_called_once_with(
-            {
-                "id": "test_identity-uuid",
-                "details": {"lang_code": "eng_ZA", "timeout_timestamp": timestamp},
-            }
+            "test_identity-uuid",
+            {"details": {"lang_code": "eng_ZA", "timeout_timestamp": timestamp}},
         )
 
     @mock.patch("changes.tasks.utils.ms_client.create_outbound")
@@ -428,7 +402,7 @@ class ProcessWhatsAppSystemEventTaskTests(WhatsAppBaseTestCase):
 
         self.create_outbound_lookup()
         self.create_identity_lookup_with_timestamp(timeout_timestamp)
-        self.update_identity_lookup_with_id_field()
+        self.update_identity_lookup()
 
         process_whatsapp_timeout_system_event.delay(
             "messageid", source.pk, [{"code": 410, "title": ("Message expired")}]
@@ -448,10 +422,8 @@ class ProcessWhatsAppSystemEventTaskTests(WhatsAppBaseTestCase):
         )
 
         mock_update_identiity.assert_called_once_with(
-            {
-                "id": "test_identity-uuid",
-                "details": {"lang_code": "eng_ZA", "timeout_timestamp": timestamp},
-            }
+            "test_identity-uuid",
+            {"details": {"lang_code": "eng_ZA", "timeout_timestamp": timestamp}},
         )
 
     @mock.patch("changes.tasks.utils.ms_client.create_outbound")
@@ -477,7 +449,7 @@ class ProcessWhatsAppSystemEventTaskTests(WhatsAppBaseTestCase):
 
         self.create_outbound_lookup()
         self.create_identity_lookup_with_timestamp(timeout_timestamp)
-        self.update_identity_lookup_with_id_field()
+        self.update_identity_lookup()
 
         process_whatsapp_timeout_system_event.delay(
             "messageid", source.pk, [{"code": 410, "title": ("Message expired")}]

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -321,8 +321,7 @@ class ProcessWhatsAppSystemEventTaskTests(WhatsAppBaseTestCase):
         self.create_outbound_lookup()
         self.create_identity_lookup()
 
-        process_whatsapp_timeout_system_event("messageid", 1542844800,
-                                              "undelivered")
+        process_whatsapp_timeout_system_event("messageid", 1542844800, "undelivered")
 
         mock_create_outbound.assert_called_once_with(
             {

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -12,7 +12,6 @@ from rest_hooks.models import model_saved
 from changes.models import Change
 from changes.signals import psh_validate_implement
 from changes.tasks import (
-    ProcessWhatsAppTimeoutSystemEvent,
     get_engage_inbound_and_reply,
     get_identity_from_msisdn,
     process_engage_helpdesk_outbound,

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -15,8 +15,8 @@ from changes.tasks import (
     get_identity_from_msisdn,
     process_engage_helpdesk_outbound,
     process_whatsapp_contact_check_fail,
-    process_whatsapp_timeout_system_event,
     process_whatsapp_system_event,
+    process_whatsapp_timeout_system_event,
     process_whatsapp_unsent_event,
     send_helpdesk_response_to_dhis2,
 )

--- a/changes/views.py
+++ b/changes/views.py
@@ -298,10 +298,9 @@ class ReceiveWhatsAppTimeoutSystemEvent(ReceiveWhatsAppBase):
 
         for item in serializer.validated_data["statuses"]:
             for error in serializer.validated_data["errors"]:
-                tasks.process_whatsapp_timeout_system_event.delay(item["id"],
-                                                                  item["timestamp"],
-                                                                  item["recipient_id"],
-                                                                  item["errors"])
+                tasks.process_whatsapp_timeout_system_event.delay(
+                    item["id"], item["timestamp"], item["recipient_id"], item["errors"]
+                )
 
         return Response(status=status.HTTP_202_ACCEPTED)
 

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -245,6 +245,9 @@ METRICS_AUTH = (
 )
 
 PREBIRTH_MIN_WEEKS = int(os.environ.get("PREBIRTH_MIN_WEEKS", "4"))
+WHATSAPP_EXPIRY_SMS_BOUNCE_DAYS = int(
+    os.environ.get("WHATSAPP_EXPIRY_SMS_BOUNCE_DAYS", "30")
+)
 
 STAGE_BASED_MESSAGING_URL = os.environ.get(
     "STAGE_BASED_MESSAGING_URL", "http://sbm/api/v1"


### PR DESCRIPTION
We want to ensure that moms/nurses always get their messages.

However, even if a user has a device that supports HSM messages, they may still delete their WhatsApp, or not have airtime/data.

WhatsApp has a TTL on templated messages that we can use for this.

The solution that was decided on this:

If a WhatsApp isn't delivered for x time period, we send them an SMS telling them that
We only send an SMS once every y time period
eg. If x is 7 days and y is a month, and there's a message that hasn't been delivered in 7 days, we tell them that. Any other failed messages within a month from that time, we do nothing with. If after a month, there'