### PR TITLE
Fix bugs in submission of helpdesk responses to DHIS2

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -12,7 +12,7 @@ from celery.task import Task
 from celery.utils.log import get_task_logger
 from demands import HTTPServiceError
 from django.conf import settings
-from django.utils import translation, dateparse
+from django.utils import dateparse, translation
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 from seed_services_client.identity_store import IdentityStoreApiClient
 from seed_services_client.stage_based_messaging import StageBasedMessagingApiClient

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -478,7 +478,7 @@ class GetEngageInboundAndReplyTests(TestCase):
                             "sha256": "f706688d5fc79cd0640cd39086dd3f3885708b7fe2e64fd",
                         },
                         "timestamp": "1540803293",
-                        "type": "image",
+                        "type": None,
                     },
                     {
                         "_vnd": {

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -466,7 +466,7 @@ class GetEngageInboundAndReplyTests(TestCase):
                                         "value": "image",
                                     }
                                 ],
-                                "inserted_at": "2018-10-29T08:54:53.123456Z"
+                                "inserted_at": "2018-10-29T08:54:53.123456Z",
                             }
                         },
                         "from": "27820001001",

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -466,6 +466,7 @@ class GetEngageInboundAndReplyTests(TestCase):
                                         "value": "image",
                                     }
                                 ],
+                                "inserted_at": "2018-10-29T08:54:53.123456Z"
                             }
                         },
                         "from": "27820001001",
@@ -477,7 +478,7 @@ class GetEngageInboundAndReplyTests(TestCase):
                             "mime_type": "image/jpeg",
                             "sha256": "f706688d5fc79cd0640cd39086dd3f3885708b7fe2e64fd",
                         },
-                        "timestamp": "1540803293",
+                        "timestamp": None,
                         "type": None,
                     },
                     {
@@ -534,10 +535,10 @@ class GetEngageInboundAndReplyTests(TestCase):
             {
                 "inbound_address": "27820001001",
                 "inbound_text": "User question as text | User question as caption",
-                "inbound_timestamp": "1540803293",
+                "inbound_timestamp": 1540803293.123456,
                 "inbound_labels": ["image", "text"],
                 "reply_text": "Operator response",
-                "reply_timestamp": "1540803363",
+                "reply_timestamp": 1540803363,
                 "reply_operator": 56748517727534413379787391391214157498,
             },
         )


### PR DESCRIPTION
This PR addresses two issues that we've been having with this task

1. It's possible that the type of the message is `null`, we need to handle that and fallback to manually trying to get the content for the content types that we know about
2. It's possible that a message has a timestamp of `null`, in which case we need to fallback to the `inserted_at` timestamp