### PR TITLE
Add Prometheus metrics

### DIFF
--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -22,7 +22,7 @@ from changes.tasks import (
     send_helpdesk_response_to_dhis2,
 )
 from registrations.models import Registration, Source
-from registrations.signals import psh_fire_created_metric, psh_validate_subscribe
+from registrations.signals import psh_validate_subscribe
 
 
 class DisconnectRegistrationSignalsMixin(object):
@@ -35,11 +35,6 @@ class DisconnectRegistrationSignalsMixin(object):
             receiver=psh_validate_subscribe,
             sender=Registration,
             dispatch_uid="psh_validate_subscribe",
-        )
-        post_save.disconnect(
-            receiver=psh_fire_created_metric,
-            sender=Registration,
-            dispatch_uid="psh_fire_created_metric",
         )
         post_save.disconnect(receiver=model_saved, dispatch_uid="instance-saved-hook")
         assert not post_save.has_listeners(Registration), (
@@ -57,11 +52,6 @@ class DisconnectRegistrationSignalsMixin(object):
             psh_validate_subscribe,
             sender=Registration,
             dispatch_uid="psh_validate_subscribe",
-        )
-        post_save.connect(
-            psh_fire_created_metric,
-            sender=Registration,
-            dispatch_uid="psh_fire_created_metric",
         )
         post_save.connect(receiver=model_saved, dispatch_uid="instance-saved-hook")
         return super().tearDown()

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -14,7 +14,7 @@ from rest_hooks.models import model_saved
 
 from ndoh_hub import utils, utils_tests
 from registrations.models import Registration, Source, SubscriptionRequest
-from registrations.signals import psh_fire_created_metric, psh_validate_subscribe
+from registrations.signals import psh_validate_subscribe
 
 from .models import Change
 from .signals import psh_validate_implement
@@ -542,11 +542,6 @@ class AuthenticatedAPITestCase(APITestCase):
             sender=Registration,
             dispatch_uid="psh_validate_subscribe",
         )
-        post_save.disconnect(
-            receiver=psh_fire_created_metric,
-            sender=Registration,
-            dispatch_uid="psh_fire_created_metric",
-        )
         post_save.disconnect(receiver=model_saved, dispatch_uid="instance-saved-hook")
         assert not has_listeners(), (
             "Registration model still has post_save listeners. Make sure"
@@ -565,11 +560,6 @@ class AuthenticatedAPITestCase(APITestCase):
             psh_validate_subscribe,
             sender=Registration,
             dispatch_uid="psh_validate_subscribe",
-        )
-        post_save.connect(
-            psh_fire_created_metric,
-            sender=Registration,
-            dispatch_uid="psh_fire_created_metric",
         )
 
     def make_source_adminuser(self):

--- a/ndoh_hub/decorators.py
+++ b/ndoh_hub/decorators.py
@@ -1,0 +1,17 @@
+import functools
+
+from django.core.exceptions import PermissionDenied
+
+
+def internal_only(view_func):
+    """
+    A view decorator which blocks access for requests coming through the load balancer.
+    """
+
+    @functools.wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        if request.META.get("HTTP_X_FORWARDED_FOR"):
+            raise PermissionDenied()
+        return view_func(request, *args, **kwargs)
+
+    return wrapper

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -229,7 +229,6 @@ CELERY_TASK_ROUTES = {
     "ndoh_hub.registrations.tasks.validate_subscribe": {"queue": "mediumpriority"},
     "ndoh_hub.changes.tasks.validate_implement": {"queue": "mediumpriority"},
     "registrations.tasks.DeliverHook": {"queue": "priority"},
-    "ndoh_hub.tasks.fire_metric": {"queue": "metrics"},
 }
 
 CELERY_TASK_SERIALIZER = "json"
@@ -241,12 +240,6 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 METRICS_REALTIME = []  # type: ignore
 METRICS_SCHEDULED = []  # type: ignore
 METRICS_SCHEDULED_TASKS = []  # type: ignore
-
-METRICS_URL = os.environ.get("METRICS_URL", "http://metrics/api/v1")
-METRICS_AUTH = (
-    os.environ.get("METRICS_AUTH_USER", "REPLACEME"),
-    os.environ.get("METRICS_AUTH_PASSWORD", "REPLACEME"),
-)
 
 PREBIRTH_MIN_WEEKS = int(os.environ.get("PREBIRTH_MIN_WEEKS", "4"))
 WHATSAPP_EXPIRY_SMS_BOUNCE_DAYS = int(

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -238,7 +238,7 @@ CELERY_ACCEPT_CONTENT = ["json"]
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 
-METRICS_REALTIME = ["registrations.created.sum"]
+METRICS_REALTIME = []  # type: ignore
 METRICS_SCHEDULED = []  # type: ignore
 METRICS_SCHEDULED_TASKS = []  # type: ignore
 

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -52,12 +52,14 @@ INSTALLED_APPS = (
     "django_filters",
     "rest_hooks",
     "simple_history",
+    "django_prometheus",
     # us
     "registrations",
     "changes",
 )
 
 MIDDLEWARE = (
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -65,6 +67,7 @@ MIDDLEWARE = (
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 )
 
 ROOT_URLCONF = "ndoh_hub.urls"
@@ -110,7 +113,8 @@ DATABASES = {
     "default": dj_database_url.config(
         default=os.environ.get(
             "HUB_DATABASE", "postgres://postgres:@localhost/ndoh_hub"
-        )
+        ),
+        engine="django_prometheus.db.backends.postgresql",
     )
 }
 

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -118,6 +118,8 @@ DATABASES = {
     )
 }
 
+PROMETHEUS_EXPORT_MIGRATIONS = False
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/

--- a/ndoh_hub/test_decorators.py
+++ b/ndoh_hub/test_decorators.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+
+class InternalOnlyTests(TestCase):
+    def test_internal_access(self):
+        """
+        Internal access should be allowed
+        """
+        url = reverse("metrics")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_external_access(self):
+        """
+        External access through the load balancer should be blocked
+        """
+        url = reverse("metrics")
+        response = self.client.get(url, HTTP_X_FORWARDED_FOR="1.2.3.4")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/ndoh_hub/urls.py
+++ b/ndoh_hub/urls.py
@@ -1,12 +1,13 @@
 import os
 
-import django_prometheus.urls
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.urls import path
+from django_prometheus import exports as django_prometheus
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.documentation import include_docs_urls
 
+from ndoh_hub.decorators import internal_only
 from registrations import views
 
 admin.site.site_header = os.environ.get("HUB_TITLE", "NDOH Hub Admin")
@@ -21,5 +22,7 @@ urlpatterns = [
     url(r"^docs/", include_docs_urls(title="NDOH Hub")),
     url(r"^", include("registrations.urls")),
     url(r"^", include("changes.urls")),
-    path("", include(django_prometheus.urls)),
+    path(
+        "metrics", internal_only(django_prometheus.ExportToDjangoView), name="metrics"
+    ),
 ]

--- a/ndoh_hub/urls.py
+++ b/ndoh_hub/urls.py
@@ -1,5 +1,6 @@
 import os
 
+import django_prometheus.urls
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.urls import path
@@ -20,4 +21,5 @@ urlpatterns = [
     url(r"^docs/", include_docs_urls(title="NDOH Hub")),
     url(r"^", include("registrations.urls")),
     url(r"^", include("changes.urls")),
+    path("", include(django_prometheus.urls)),
 ]

--- a/ndoh_hub/utils.py
+++ b/ndoh_hub/utils.py
@@ -4,7 +4,6 @@ import datetime
 import json
 
 import six
-from celery.task import Task
 from django.conf import settings
 from rest_framework.authentication import TokenAuthentication
 from seed_services_client.identity_store import IdentityStoreApiClient
@@ -313,24 +312,6 @@ def get_metric_client(session=None):
     return MetricsApiClient(
         url=settings.METRICS_URL, auth=settings.METRICS_AUTH, session=session
     )
-
-
-class FireMetric(Task):
-
-    """ Fires a metric using the MetricsApiClient
-    """
-
-    name = "ndoh_hub.tasks.fire_metric"
-
-    def run(self, metric_name, metric_value, session=None, **kwargs):
-        metric_value = float(metric_value)
-        metric = {metric_name: metric_value}
-        metric_client = get_metric_client(session=session)
-        metric_client.fire_metrics(**metric)
-        return "Fired metric <%s> with value <%s>" % (metric_name, metric_value)
-
-
-fire_metric = FireMetric()
 
 
 def json_decode(data):

--- a/ndoh_hub/utils.py
+++ b/ndoh_hub/utils.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from rest_framework.authentication import TokenAuthentication
 from seed_services_client.identity_store import IdentityStoreApiClient
 from seed_services_client.message_sender import MessageSenderApiClient
-from seed_services_client.metrics import MetricsApiClient
 from seed_services_client.stage_based_messaging import StageBasedMessagingApiClient
 
 from registrations.models import PositionTracker
@@ -306,12 +305,6 @@ def get_available_metrics():
     available_metrics.extend(settings.METRICS_REALTIME)
     available_metrics.extend(settings.METRICS_SCHEDULED)
     return available_metrics
-
-
-def get_metric_client(session=None):
-    return MetricsApiClient(
-        url=settings.METRICS_URL, auth=settings.METRICS_AUTH, session=session
-    )
 
 
 def json_decode(data):

--- a/registrations/apps.py
+++ b/registrations/apps.py
@@ -7,16 +7,10 @@ class RegistrationsAppConfig(AppConfig):
     name = "registrations"
 
     def ready(self):
-        from .signals import psh_validate_subscribe, psh_fire_created_metric
+        from .signals import psh_validate_subscribe
 
         post_save.connect(
             psh_validate_subscribe,
             sender="registrations.Registration",
             dispatch_uid="psh_validate_subscribe",
-        )
-
-        post_save.connect(
-            psh_fire_created_metric,
-            sender="registrations.Registration",
-            dispatch_uid="psh_fire_created_metric",
         )

--- a/registrations/signals.py
+++ b/registrations/signals.py
@@ -8,14 +8,3 @@ def psh_validate_subscribe(sender, instance, created, **kwargs):
         from .tasks import validate_subscribe
 
         validate_subscribe.apply_async(kwargs={"registration_id": str(instance.id)})
-
-
-def psh_fire_created_metric(sender, instance, created, **kwargs):
-    """ Post save hook to fire Registration created metric
-    """
-    if created:
-        from ndoh_hub import utils
-
-        utils.fire_metric.apply_async(
-            kwargs={"metric_name": "registrations.created.sum", "metric_value": 1.0}
-        )

--- a/registrations/test_tasks.py
+++ b/registrations/test_tasks.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 from ndoh_hub import utils_tests
 from registrations.models import Registration, Source, SubscriptionRequest
 from registrations.serializers import RegistrationSerializer
-from registrations.signals import psh_fire_created_metric, psh_validate_subscribe
+from registrations.signals import psh_validate_subscribe
 from registrations.tasks import validate_subscribe
 from registrations.tasks import validate_subscribe_jembi_app_registration as task
 
@@ -24,22 +24,12 @@ class ValidateSubscribeJembiAppRegistrationsTests(TestCase):
             sender=Registration,
             dispatch_uid="psh_validate_subscribe",
         )
-        post_save.disconnect(
-            receiver=psh_fire_created_metric,
-            sender=Registration,
-            dispatch_uid="psh_fire_created_metric",
-        )
 
     def tearDown(self):
         post_save.connect(
             psh_validate_subscribe,
             sender=Registration,
             dispatch_uid="psh_validate_subscribe",
-        )
-        post_save.connect(
-            psh_fire_created_metric,
-            sender=Registration,
-            dispatch_uid="psh_fire_created_metric",
         )
 
     @responses.activate

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = */migrations/*.py,*/manage.py,ve/*
 max-line-length = 88
 
 [tool:pytest]
-python_files=registrations/test*.py registrations/**/test*.py changes/test*.py changes/**/test*.py
+python_files=registrations/test*.py registrations/**/test*.py changes/test*.py changes/**/test*.py ndoh_hub/test*.py
 addopts = --verbose --ds=ndoh_hub.testsettings --ignore=ve --cov=ndoh_hub --cov=registrations --cov=changes --no-cov-on-fail
 
 [coverage:run]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "django-simple-history==2.4.0",
         "openpyxl==2.5.9",
         "iso-639==0.4.5",
-        "django-prometheus=1.0.15",
+        "django-prometheus==1.0.15",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "django-simple-history==2.4.0",
         "openpyxl==2.5.9",
         "iso-639==0.4.5",
+        "django-prometheus=1.0.15",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This PR adds default Prometheus metrics scraping for python and Django, and a restricted metrics endpoint for exported the metrics.

It also removes any metric that are no longer required.