### PR TITLE
Feature/momza 1111 fix loss switch lang code

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -145,6 +145,7 @@ class ValidateImplement(Task):
         whatsapp = False
         messagesets = list(sbm_client.get_messagesets()["results"])
         for sub in active_subs:
+            lang = sub["lang"]
             for ms in messagesets:
                 if ms["id"] == sub["messageset"]:
                     short_name = ms["short_name"]
@@ -172,14 +173,11 @@ class ValidateImplement(Task):
             r = utils.get_messageset_schedule_sequence(short_name, 0)
             msgset_id, msgset_schedule, next_sequence_number = r
 
-            self.log.info("Determining language")
-            identity = is_client.get_identity(change.registrant_id)
-
             subscription = {
                 "identity": change.registrant_id,
                 "messageset": msgset_id,
                 "next_sequence_number": next_sequence_number,
-                "lang": identity["details"]["lang_code"],
+                "lang": lang,
                 "schedule": msgset_schedule,
             }
 

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -2082,7 +2082,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(change.validated, True)
         self.assertEqual(Registration.objects.all().count(), 2)
         self.assertEqual(SubscriptionRequest.objects.all().count(), 1)
-        self.assertEqual(len(responses.calls), 11)
+        self.assertEqual(len(responses.calls), 10)
 
         # Check Jembi POST
         self.assertEqual(
@@ -2150,7 +2150,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(change.validated, True)
         self.assertEqual(Registration.objects.all().count(), 2)
         self.assertEqual(SubscriptionRequest.objects.all().count(), 1)
-        self.assertEqual(len(responses.calls), 9)
+        self.assertEqual(len(responses.calls), 8)
 
         [sub_req] = SubscriptionRequest.objects.all()
         self.assertEqual(sub_req.messageset, 81)
@@ -2630,7 +2630,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(change.validated, True)
         self.assertEqual(Registration.objects.all().count(), 2)
         self.assertEqual(SubscriptionRequest.objects.all().count(), 1)
-        self.assertEqual(len(responses.calls), 11)
+        self.assertEqual(len(responses.calls), 10)
         subreq = SubscriptionRequest.objects.last()
         self.assertEqual(subreq.messageset, 51)
         self.assertEqual(subreq.schedule, 151)


### PR DESCRIPTION
Currently for loss switches, we look for the language code in lang_code on the identity, but it seems like not all identities have this field. 

This PR fixes by setting the language the same as their existing messageset