### PR TITLE
Add setting for toggling unsent event action

### DIFF
--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -13,7 +13,10 @@ import os
 
 import dj_database_url
 import django.conf.locale
+import environ
 from kombu import Exchange, Queue
+
+env = environ.Env(ENABLE_UNSENT_EVENT_ACTION=(bool, True))
 
 # Support SVG on admin
 mimetypes.add_type("image/svg+xml", ".svg", True)
@@ -275,3 +278,5 @@ OPTOUT_USSD_CODE = os.environ.get("OPTOUT_USSD_CODE", "*134*550*1#")
 
 ENGAGE_HMAC_SECRET = os.environ.get("ENGAGE_HMAC_SECRET", "REPLACEME")
 ENGAGE_CONTEXT_HMAC_SECRET = os.environ.get("ENGAGE_CONTEXT_HMAC_SECRET", "REPLACEME")
+
+ENABLE_UNSENT_EVENT_ACTION = env("ENABLE_UNSENT_EVENT_ACTION")

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "djangorestframework==3.8.2",
         "coreapi==2.3.3",
         "dj-database-url==0.5.0",
+        "django-environ==0.4.5",
         "psycopg2==2.7.5",
         "raven==6.9.0",
         "django-filter==2.0.0",


### PR DESCRIPTION
If WhatsApp disable our template, then they send us the same event as when a
user's phone doesn't support tempalted messages, so we need to have a way to
switch this feature off in case our template gets disabled