### PR TITLE
Add actions to Turn/engage context

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -5,6 +5,7 @@ from rest_framework.validators import UniqueValidator
 from rest_hooks.models import Hook
 
 from changes.fields import PhoneNumberField
+from changes.serializers import ChangeSerializer
 from ndoh_hub import utils
 from registrations import validators
 from registrations.models import PositionTracker
@@ -332,3 +333,8 @@ class EngageContextSerializer(serializers.Serializer):
             return result
 
     messages = serializers.ListField(child=Message(), required=False)
+
+
+class EngageActionSerializer(serializers.Serializer):
+    address = PhoneNumberField(country_code="ZA")
+    payload = ChangeSerializer()

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -501,6 +501,22 @@ class EngageContextViewTests(APITestCase):
                         "data": {"channel": "sms"},
                     },
                 },
+                "opt_out": {
+                    "description": "Opt out",
+                    "url": "/api/v1/engage/action",
+                    "payload": {
+                        "registrant_id": "mother-uuid",
+                        "action": "momconnect_loss_optout",
+                    },
+                    "options": {
+                        "miscarriage": "Miscarriage",
+                        "stillbirth": "Baby was stillborn",
+                        "babyloss": "Baby died",
+                        "not_useful": "Messages not useful",
+                        "other": "Other",
+                        "unknown": "Unknown",
+                    },
+                },
             },
         )
 
@@ -663,4 +679,116 @@ class EngageContextViewTests(APITestCase):
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "switch_channel")
+        self.assertTrue(change.validated)
+
+    @responses.activate
+    @override_settings(ENGAGE_CONTEXT_HMAC_SECRET="hmac-secret")
+    def test_nonloss_optout(self):
+        """
+        If one of the nonloss optouts is selected, a nonloss optout should be created
+        """
+        mother_uuid = str(uuid4())
+        self.add_authorization_token()
+        self.add_identity_lookup_by_address_fixture(
+            msisdn="+27820001001",
+            identity_uuid=mother_uuid,
+            details={"mom_dob": "1980-08-08"},
+        )
+        self.add_subscription_lookup(
+            identity_uuid=mother_uuid, subscriptions=["MomConnect Pregnancy"]
+        )
+        user = User.objects.create_user("test2")
+        source = Source.objects.create(user=user)
+        Registration.objects.create(
+            reg_type="momconnect_prebirth",
+            registrant_id=mother_uuid,
+            data={"faccode": "123456", "edd": "2018-12-15"},
+            source=source,
+        )
+
+        url = reverse("engage-context")
+        data = {"messages": [{"from": "27820001001"}]}
+        response = self.client.post(
+            url,
+            data,
+            format="json",
+            HTTP_X_ENGAGE_HOOK_SIGNATURE=self.generate_hmac_signature(
+                data, "hmac-secret"
+            ),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        action = response.json()["actions"]["opt_out"]
+        action["payload"]["option"] = "not_useful"
+        data = {"address": "+27820001001", "payload": action["payload"]}
+        response = self.client.post(
+            action["url"],
+            data,
+            format="json",
+            HTTP_X_ENGAGE_HOOK_SIGNATURE=self.generate_hmac_signature(
+                data, "hmac-secret"
+            ),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        [change] = Change.objects.all()
+        self.assertEqual(change.registrant_id, mother_uuid)
+        self.assertEqual(change.action, "momconnect_nonloss_optout")
+        self.assertEqual(change.data, {"reason": "not_useful"})
+        self.assertTrue(change.validated)
+
+    @responses.activate
+    @override_settings(ENGAGE_CONTEXT_HMAC_SECRET="hmac-secret")
+    def test_loss_optout(self):
+        """
+        If one of the loss optouts is selected, a loss optout should be created
+        """
+        mother_uuid = str(uuid4())
+        self.add_authorization_token()
+        self.add_identity_lookup_by_address_fixture(
+            msisdn="+27820001001",
+            identity_uuid=mother_uuid,
+            details={"mom_dob": "1980-08-08"},
+        )
+        self.add_subscription_lookup(
+            identity_uuid=mother_uuid, subscriptions=["MomConnect Pregnancy"]
+        )
+        user = User.objects.create_user("test2")
+        source = Source.objects.create(user=user)
+        Registration.objects.create(
+            reg_type="momconnect_prebirth",
+            registrant_id=mother_uuid,
+            data={"faccode": "123456", "edd": "2018-12-15"},
+            source=source,
+        )
+
+        url = reverse("engage-context")
+        data = {"messages": [{"from": "27820001001"}]}
+        response = self.client.post(
+            url,
+            data,
+            format="json",
+            HTTP_X_ENGAGE_HOOK_SIGNATURE=self.generate_hmac_signature(
+                data, "hmac-secret"
+            ),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        action = response.json()["actions"]["opt_out"]
+        action["payload"]["option"] = "miscarriage"
+        data = {"address": "+27820001001", "payload": action["payload"]}
+        response = self.client.post(
+            action["url"],
+            data,
+            format="json",
+            HTTP_X_ENGAGE_HOOK_SIGNATURE=self.generate_hmac_signature(
+                data, "hmac-secret"
+            ),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        [change] = Change.objects.all()
+        self.assertEqual(change.registrant_id, mother_uuid)
+        self.assertEqual(change.action, "momconnect_loss_optout")
+        self.assertEqual(change.data, {"reason": "miscarriage"})
         self.assertTrue(change.validated)

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -416,7 +416,8 @@ class EngageContextViewTests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            response.json(), {"version": "1.0.0-alpha", "context_objects": data}
+            response.json(),
+            {"version": "1.0.0-alpha", "context_objects": data, "actions": {}},
         )
 
     @responses.activate
@@ -457,11 +458,12 @@ class EngageContextViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = response.json()
-        contect_objects = response.pop("context_objects")
+        context_objects = response.pop("context_objects")
+        actions = response.pop("actions")
         self.assertEqual(response, {"version": "1.0.0-alpha"})
 
         self.assertEqual(
-            contect_objects["mother_details"],
+            context_objects["mother_details"],
             {
                 "Facility Code": "123456",
                 "Registration Type": "MomConnect pregnancy registration",
@@ -471,6 +473,8 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(
-            contect_objects["subscriptions"],
+            context_objects["subscriptions"],
             ["MomConnect Pregnancy WhatsApp", "Service Info WhatsApp"],
         )
+
+        self.assertEqual(actions, {})

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -491,7 +491,16 @@ class EngageContextViewTests(APITestCase):
                         "action": "baby_switch",
                         "data": {},
                     },
-                }
+                },
+                "switch_to_sms": {
+                    "description": "Switch channel to SMS",
+                    "url": "/api/v1/engage/action",
+                    "payload": {
+                        "registrant_id": "mother-uuid",
+                        "action": "switch_channel",
+                        "data": {"channel": "sms"},
+                    },
+                },
             },
         )
 
@@ -587,4 +596,71 @@ class EngageContextViewTests(APITestCase):
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "baby_switch")
+        self.assertTrue(change.validated)
+
+    @responses.activate
+    @override_settings(ENGAGE_CONTEXT_HMAC_SECRET="hmac-secret")
+    def test_switch_channel_whatsapp(self):
+        """
+        If the user isn't subscribed to a whatsapp messageset, then there should
+        instead be a change to whatsapp action.
+        """
+        mother_uuid = str(uuid4())
+        self.add_authorization_token()
+        self.add_identity_lookup_by_address_fixture(
+            msisdn="+27820001001",
+            identity_uuid=mother_uuid,
+            details={"mom_dob": "1980-08-08"},
+        )
+        self.add_subscription_lookup(
+            identity_uuid=mother_uuid, subscriptions=["MomConnect Pregnancy"]
+        )
+        user = User.objects.create_user("test2")
+        source = Source.objects.create(user=user)
+        Registration.objects.create(
+            reg_type="momconnect_prebirth",
+            registrant_id=mother_uuid,
+            data={"faccode": "123456", "edd": "2018-12-15"},
+            source=source,
+        )
+
+        url = reverse("engage-context")
+        data = {"messages": [{"from": "27820001001"}]}
+        response = self.client.post(
+            url,
+            data,
+            format="json",
+            HTTP_X_ENGAGE_HOOK_SIGNATURE=self.generate_hmac_signature(
+                data, "hmac-secret"
+            ),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.json()["actions"]["switch_to_whatsapp"],
+            {
+                "description": "Switch channel to WhatsApp",
+                "url": "/api/v1/engage/action",
+                "payload": {
+                    "registrant_id": mother_uuid,
+                    "action": "switch_channel",
+                    "data": {"channel": "whatsapp"},
+                },
+            },
+        )
+
+        action = response.json()["actions"]["switch_to_whatsapp"]
+        data = {"address": "+27820001001", "payload": action["payload"]}
+        response = self.client.post(
+            action["url"],
+            data,
+            format="json",
+            HTTP_X_ENGAGE_HOOK_SIGNATURE=self.generate_hmac_signature(
+                data, "hmac-secret"
+            ),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        [change] = Change.objects.all()
+        self.assertEqual(change.registrant_id, mother_uuid)
+        self.assertEqual(change.action, "switch_channel")
         self.assertTrue(change.validated)

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -379,7 +379,7 @@ class EngageContextViewTests(APITestCase):
             response.json(),
             {
                 "capabilities": {
-                    "actions": False,
+                    "actions": True,
                     "context_objects": [
                         {
                             "title": "Mother's Details",

--- a/registrations/urls.py
+++ b/registrations/urls.py
@@ -33,5 +33,8 @@ urlpatterns = [
         views.EngageContextView.as_view(),
         name="engage-context",
     ),
+    path(
+        "api/v1/engage/action", views.EngageActionView.as_view(), name="engage-action"
+    ),
     url(r"^api/v1/", include(router.urls)),
 ]

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -814,6 +814,27 @@ class EngageContextView(EngageBaseView, generics.CreateAPIView):
                 },
             }
 
+        if any("whatsapp" in sub.lower() for sub in subscriptions):
+            actions["switch_to_sms"] = {
+                "description": "Switch channel to SMS",
+                "url": reverse("engage-action"),
+                "payload": {
+                    "registrant_id": identity_id,
+                    "action": "switch_channel",
+                    "data": {"channel": "sms"},
+                },
+            }
+        else:
+            actions["switch_to_whatsapp"] = {
+                "description": "Switch channel to WhatsApp",
+                "url": reverse("engage-action"),
+                "payload": {
+                    "registrant_id": identity_id,
+                    "action": "switch_channel",
+                    "data": {"channel": "whatsapp"},
+                },
+            }
+
         return actions
 
     def post(self, request):

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -852,6 +852,19 @@ class EngageContextView(EngageBaseView, generics.CreateAPIView):
             },
         }
 
+        actions["switch_to_loss"] = {
+            "description": "Switch to loss messaging",
+            "url": reverse("engage-action"),
+            "payload": {
+                "registrant_id": identity_id,
+                "action": "momconnect_loss_switch",
+            },
+            "options": {
+                "miscarriage": "Miscarriage",
+                "stillbirth": "Baby was stillborn",
+                "babyloss": "Baby died",
+            },
+        }
         return actions
 
     def post(self, request):
@@ -921,6 +934,8 @@ class EngageActionView(EngageBaseView, generics.CreateAPIView):
             change_data["data"] = {"reason": option}
             if option in ["not_useful", "other", "unknown"]:
                 change_data["action"] = "momconnect_nonloss_optout"
+        if change_data.get("action") == "momconnect_loss_switch":
+            change_data["data"] = {"reason": option}
 
         change = Change.objects.create(**change_data)
 

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -865,6 +865,29 @@ class EngageContextView(EngageBaseView, generics.CreateAPIView):
                 "babyloss": "Baby died",
             },
         }
+
+        actions["switch_language"] = {
+            "description": "Change language",
+            "url": reverse("engage-action"),
+            "payload": {
+                "registrant_id": identity_id,
+                "action": "momconnect_change_language",
+            },
+            "options": {
+                "zul_ZA": "isiZulu",
+                "xho_ZA": "isiXhosa",
+                "afr_ZA": "Afrikaans",
+                "eng_ZA": "English",
+                "nso_ZA": "Sesotho sa Leboa / Sepedi",
+                "tsn_ZA": "Setswana",
+                "sot_ZA": "Sesotho",
+                "tso_ZA": "Xitsonga",
+                "ssw_ZA": "siSwati",
+                "ven_ZA": "Tshivenda",
+                "nbl_ZA": "isiNdebele",
+            },
+        }
+
         return actions
 
     def post(self, request):
@@ -936,6 +959,8 @@ class EngageActionView(EngageBaseView, generics.CreateAPIView):
                 change_data["action"] = "momconnect_nonloss_optout"
         if change_data.get("action") == "momconnect_loss_switch":
             change_data["data"] = {"reason": option}
+        if change_data.get("action") == "momconnect_change_language":
+            change_data["data"] = {"language": option}
 
         change = Change.objects.create(**change_data)
 

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -823,4 +823,6 @@ class EngageContextView(generics.CreateAPIView):
         if subscriptions:
             context["subscriptions"] = subscriptions
 
-        return Response({"version": "1.0.0-alpha", "context_objects": context})
+        return Response(
+            {"version": "1.0.0-alpha", "context_objects": context, "actions": {}}
+        )

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -17,6 +17,7 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import IntegrityError
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
 from django.utils import timezone
 from requests.exceptions import RequestException
 from rest_framework import generics, mixins, status, viewsets
@@ -37,11 +38,14 @@ from rest_hooks.models import Hook
 from seed_services_client.identity_store import IdentityStoreApiClient
 from seed_services_client.stage_based_messaging import StageBasedMessagingApiClient
 
+from changes.models import Change
+from changes.serializers import ChangeSerializer
 from ndoh_hub.utils import get_available_metrics
 
 from .models import PositionTracker, Registration, Source
 from .serializers import (
     CreateUserSerializer,
+    EngageActionSerializer,
     EngageContextSerializer,
     GroupSerializer,
     HookSerializer,
@@ -651,7 +655,25 @@ class PositionTrackerViewset(
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-class EngageContextView(generics.CreateAPIView):
+class EngageBaseView(object):
+    """
+    A base view for shared functionality between Engage views
+    """
+
+    def validate_signature(self, request):
+        secret = settings.ENGAGE_CONTEXT_HMAC_SECRET
+        try:
+            signature = request.META["HTTP_X_ENGAGE_HOOK_SIGNATURE"]
+        except KeyError:
+            raise AuthenticationFailed("X-Engage-Hook-Signature header required")
+
+        h = hmac.new(secret.encode(), request.body, sha256)
+
+        if not hmac.compare_digest(base64.b64encode(h.digest()).decode(), signature):
+            raise AuthenticationFailed("Invalid hook signature")
+
+
+class EngageContextView(EngageBaseView, generics.CreateAPIView):
     serializer_class = EngageContextSerializer
 
     # Since these external requests are happening in the request loop, we need to
@@ -674,18 +696,6 @@ class EngageContextView(generics.CreateAPIView):
         ("edd", "Expected Due Date"),
         ("mom_dob", "Date of Birth"),
     )
-
-    def validate_signature(self, request):
-        secret = settings.ENGAGE_CONTEXT_HMAC_SECRET
-        try:
-            signature = request.META["HTTP_X_ENGAGE_HOOK_SIGNATURE"]
-        except KeyError:
-            raise AuthenticationFailed("X-Engage-Hook-Signature header required")
-
-        h = hmac.new(secret.encode(), request.body, sha256)
-
-        if not hmac.compare_digest(base64.b64encode(h.digest()).decode(), signature):
-            raise AuthenticationFailed("Invalid hook signature")
 
     def get_msisdn(self, data):
         """
@@ -782,6 +792,30 @@ class EngageContextView(generics.CreateAPIView):
 
         return result
 
+    def generate_actions(self, identity, subscriptions):
+        """
+        Returns an object describing the list of available actions
+        """
+        actions = {}
+
+        try:
+            identity_id = identity["id"]
+        except (KeyError, TypeError):
+            return actions
+
+        if any("pregnancy" in sub.lower() for sub in subscriptions):
+            actions["baby_switch"] = {
+                "description": "Switch to baby messaging",
+                "url": reverse("engage-action"),
+                "payload": {
+                    "registrant_id": identity_id,
+                    "action": "baby_switch",
+                    "data": {},
+                },
+            }
+
+        return actions
+
     def post(self, request):
         self.validate_signature(request)
 
@@ -824,5 +858,25 @@ class EngageContextView(generics.CreateAPIView):
             context["subscriptions"] = subscriptions
 
         return Response(
-            {"version": "1.0.0-alpha", "context_objects": context, "actions": {}}
+            {
+                "version": "1.0.0-alpha",
+                "context_objects": context,
+                "actions": self.generate_actions(identity, subscriptions),
+            }
         )
+
+
+class EngageActionView(EngageBaseView, generics.CreateAPIView):
+    serializer_class = EngageActionSerializer
+
+    def post(self, request):
+        self.validate_signature(request)
+
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        change_data = serializer.validated_data["payload"]
+        change_data["created_by"] = change_data["updated_by"] = request.user
+        change_data["source"] = Source.objects.get(user=self.request.user)
+        change = Change.objects.create(**change_data)
+
+        return Response(ChangeSerializer(change).data, status=status.HTTP_201_CREATED)

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -788,7 +788,7 @@ class EngageContextView(generics.CreateAPIView):
         if "handshake" in request.data:
             resp = {
                 "capabilities": {
-                    "actions": False,
+                    "actions": True,
                     "context_objects": [
                         {
                             "title": "Mother's Details",


### PR DESCRIPTION
This PR adds the following actions for helpdesk operators, using the new Turn actions API (https://whatsapp.praekelt.org/docs/index.html#actions):
Switch to baby messaging
Switch channel
Opt out
Switch to loss messaging
Language switch