### PR TITLE
Update EngageActionView to get option and return refresh header

### DIFF
--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -643,7 +643,7 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.headers["X-Turn-Integration-Refresh"], "true")
+        self.assertEqual(response["X-Turn-Integration-Refresh"], "true")
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "baby_switch")
@@ -769,7 +769,7 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.headers["X-Turn-Integration-Refresh"], "true")
+        self.assertEqual(response["X-Turn-Integration-Refresh"], "true")
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "momconnect_nonloss_optout")
@@ -829,7 +829,7 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.headers["X-Turn-Integration-Refresh"], "true")
+        self.assertEqual(response["X-Turn-Integration-Refresh"], "true")
 
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
@@ -890,7 +890,7 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.headers["X-Turn-Integration-Refresh"], "true")
+        self.assertEqual(response["X-Turn-Integration-Refresh"], "true")
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "momconnect_loss_switch")
@@ -950,7 +950,7 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.headers["X-Turn-Integration-Refresh"], "true")
+        self.assertEqual(response["X-Turn-Integration-Refresh"], "true")
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "momconnect_change_language")

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -757,7 +757,7 @@ class EngageContextViewTests(APITestCase):
         data = {
             "address": "+27820001001",
             "option": "not_useful",
-            "payload": action["payload"]
+            "payload": action["payload"],
         }
         response = self.client.post(
             action["url"],
@@ -817,7 +817,7 @@ class EngageContextViewTests(APITestCase):
         data = {
             "address": "+27820001001",
             "option": "miscarriage",
-            "payload": action["payload"]
+            "payload": action["payload"],
         }
         response = self.client.post(
             action["url"],
@@ -878,7 +878,7 @@ class EngageContextViewTests(APITestCase):
         data = {
             "address": "+27820001001",
             "option": "miscarriage",
-            "payload": action["payload"]
+            "payload": action["payload"],
         }
         response = self.client.post(
             action["url"],
@@ -938,7 +938,7 @@ class EngageContextViewTests(APITestCase):
         data = {
             "address": "+27820001001",
             "option": "zul_ZA",
-            "payload": action["payload"]
+            "payload": action["payload"],
         }
         response = self.client.post(
             action["url"],

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -256,7 +256,7 @@ class PositionTrackerViewsetTests(AuthenticatedAPITestCase):
 
 
 class EngageActionViewTests(APITestCase):
-     
+
     def add_authorization_token(self):
         """
         Adds credentials to the current client

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -756,7 +756,7 @@ class EngageContextViewTests(APITestCase):
         action = response.json()["actions"]["opt_out"]
         data = {
             "address": "+27820001001",
-            "option": "no_useful",
+            "option": "not_useful",
             "payload": action["payload"]
         }
         response = self.client.post(

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -344,7 +344,7 @@ class EngageActionViewTests(APITestCase):
             ),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.headers, %{"foo": "bar"})
+        self.assertEqual(response.headers, {"foo": "bar"})
         self.assertEqual(
             response.json(),
             {"version": "1.0.0-alpha", "context_objects": data, "actions": {}},

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -967,6 +967,5 @@ class EngageActionView(EngageBaseView, generics.CreateAPIView):
         return Response(
             ChangeSerializer(change).data,
             status=status.HTTP_201_CREATED,
-            headers={
-                'X-Turn-Integration-Refresh': 'true'
-            })
+            headers={"X-Turn-Integration-Refresh": "true"},
+        )

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -965,8 +965,8 @@ class EngageActionView(EngageBaseView, generics.CreateAPIView):
         change = Change.objects.create(**change_data)
 
         return Response(
-            ChangeSerializer(change).data, 
-            status=status.HTTP_201_CREATED, 
+            ChangeSerializer(change).data,
+            status=status.HTTP_201_CREATED,
             headers={
                 'X-Turn-Integration-Refresh': 'true'
             })

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -947,7 +947,7 @@ class EngageActionView(EngageBaseView, generics.CreateAPIView):
         self.validate_signature(request)
 
         serializer = self.get_serializer(data=request.data)
-        option = request.data.get("payload", {}).pop("option", None)
+        option = request.data.pop("option", None)
         serializer.is_valid(raise_exception=True)
         change_data = serializer.validated_data["payload"]
         change_data["created_by"] = change_data["updated_by"] = request.user
@@ -964,4 +964,9 @@ class EngageActionView(EngageBaseView, generics.CreateAPIView):
 
         change = Change.objects.create(**change_data)
 
-        return Response(ChangeSerializer(change).data, status=status.HTTP_201_CREATED)
+        return Response(
+            ChangeSerializer(change).data, 
+            status=status.HTTP_201_CREATED, 
+            headers={
+                'X-Turn-Integration-Refresh': 'true'
+            })


### PR DESCRIPTION
The Turn API for this has changed slightly. The `option` is no longer in
the `payload` but a top level attribute instead.

Also, we can force a refresh of the UI by returning the `X-Turn-Integration-Refresh` header
set to `true`.