### PR TITLE
Update language mapping

### DIFF
--- a/changes/tests.py
+++ b/changes/tests.py
@@ -3875,7 +3875,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
                 "metadata": {
                     "template": {
                         "name": "mc_important_info",
-                        "language": "nb",
+                        "language": "en",
                         "variables": [
                             "We notice that you have been receiving MomConnect msgs "
                             "on WhatsApp for children between 1 - 2. Messages for "

--- a/ndoh_hub/constants.py
+++ b/ndoh_hub/constants.py
@@ -29,15 +29,15 @@ LANGUAGES = [
 # Since WhatsApp doesn't support most of South Africa's official languages, we create
 # a mapping to languages that we don't use for missing languages
 WHATSAPP_LANGUAGE_MAP = {
-    "zul_ZA": "uz",
-    "xho_ZA": "th",
+    "zul_ZA": "en",
+    "xho_ZA": "en",
     "afr_ZA": "af",
     "eng_ZA": "en",
-    "nso_ZA": "sl",
-    "tsn_ZA": "bn",
-    "sot_ZA": "ta",
-    "tso_ZA": "sv",
-    "ssw_ZA": "sw",
-    "ven_ZA": "vi",
-    "nbl_ZA": "nb",
+    "nso_ZA": "en",
+    "tsn_ZA": "en",
+    "sot_ZA": "en",
+    "tso_ZA": "en",
+    "ssw_ZA": "en",
+    "ven_ZA": "en",
+    "nbl_ZA": "en",
 }

--- a/scripts/migrate_to_whatsapp_templates/tests/test_prebirth1.py
+++ b/scripts/migrate_to_whatsapp_templates/tests/test_prebirth1.py
@@ -58,7 +58,7 @@ class TestPrebirth1(unittest.TestCase):
                 "foo": "bar",
                 "template": {
                     "name": "mc_prebirth",
-                    "language": "uz",
+                    "language": "en",
                     "variables": ["6", "Test message"],
                 },
             },


### PR DESCRIPTION
WhatsApp don't like our solution of mapping unsupported languages to supported
ones, so we need to make all non-supported languages point to english templates