### PR TITLE
Refresh context on completion of action

### DIFF
--- a/changes/models.py
+++ b/changes/models.py
@@ -73,5 +73,17 @@ class Change(models.Model):
     )
     user = property(lambda self: self.created_by)
 
+    @property
+    def is_engage_action(self):
+        return "engage" in self.data
+
+    def async_refresh_engage_context(self):
+        from changes.tasks import refresh_engage_context
+
+        engage = self.data["engage"]
+        refresh_engage_context.delay(
+            engage["integration_uuid"], engage["integration_action_uuid"]
+        )
+
     def __str__(self):
         return str(self.id)

--- a/changes/test_models.py
+++ b/changes/test_models.py
@@ -1,0 +1,56 @@
+from unittest import mock
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from changes.models import Change
+from registrations.models import Source
+
+
+class ChangeTests(TestCase):
+    def test_is_engage_action(self):
+        """
+        Should return True if the Change is from an engage action, and false otherwise.
+        """
+        user = User.objects.create_user("test")
+        source = Source.objects.create(user=user)
+        change = Change.objects.create(
+            registrant_id="test-registrant-id",
+            action="switch_channel",
+            data={},
+            source=source,
+        )
+        self.assertFalse(change.is_engage_action)
+
+        change.data = {
+            "engage": {
+                "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+                "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
+            }
+        }
+        change.save()
+        self.assertTrue(change.is_engage_action)
+
+    @mock.patch("changes.tasks.refresh_engage_context")
+    def test_async_refresh_engage_context(self, task):
+        """
+        Asynchronously calls the task with the correct arguments
+        """
+        user = User.objects.create_user("test")
+        source = Source.objects.create(user=user)
+        change = Change.objects.create(
+            registrant_id="test-registrant-id",
+            action="switch_channel",
+            data={
+                "engage": {
+                    "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+                    "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
+                }
+            },
+            source=source,
+        )
+        change.async_refresh_engage_context()
+        task.delay.assert_called_once_with(
+            "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+            "009d3a39-326c-42f3-af72-b5ddbece219a",
+        )

--- a/ndoh_hub/utils.py
+++ b/ndoh_hub/utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division
 import datetime
 import json
 
+import pkg_resources
 import six
 from django.conf import settings
 from rest_framework.authentication import TokenAuthentication
@@ -31,6 +32,8 @@ is_client = IdentityStoreApiClient(
 ms_client = MessageSenderApiClient(
     api_url=settings.MESSAGE_SENDER_URL, auth_token=settings.MESSAGE_SENDER_TOKEN
 )
+
+VERSION = pkg_resources.require("ndoh-hub")[0].version
 
 
 def get_identity_msisdn(registrant_id):

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -337,4 +337,6 @@ class EngageContextSerializer(serializers.Serializer):
 
 class EngageActionSerializer(serializers.Serializer):
     address = PhoneNumberField(country_code="ZA")
+    integration_uuid = serializers.CharField()
+    integration_action_uuid = serializers.CharField()
     payload = ChangeSerializer()

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -632,7 +632,12 @@ class EngageContextViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         action = response.json()["actions"]["baby_switch"]
-        data = {"address": "+27820001001", "payload": action["payload"]}
+        data = {
+            "address": "+27820001001",
+            "payload": action["payload"],
+            "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+            "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
+        }
         response = self.client.post(
             action["url"],
             data,
@@ -643,10 +648,18 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response["X-Turn-Integration-Refresh"], "true")
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "baby_switch")
+        self.assertEqual(
+            change.data,
+            {
+                "engage": {
+                    "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+                    "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
+                }
+            },
+        )
         self.assertTrue(change.validated)
 
     @responses.activate
@@ -700,7 +713,12 @@ class EngageContextViewTests(APITestCase):
         )
 
         action = response.json()["actions"]["switch_to_whatsapp"]
-        data = {"address": "+27820001001", "payload": action["payload"]}
+        data = {
+            "address": "+27820001001",
+            "payload": action["payload"],
+            "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+            "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
+        }
         response = self.client.post(
             action["url"],
             data,
@@ -714,6 +732,16 @@ class EngageContextViewTests(APITestCase):
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "switch_channel")
+        self.assertEqual(
+            change.data,
+            {
+                "channel": "whatsapp",
+                "engage": {
+                    "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+                    "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
+                },
+            },
+        )
         self.assertTrue(change.validated)
 
     @responses.activate
@@ -758,6 +786,8 @@ class EngageContextViewTests(APITestCase):
             "address": "+27820001001",
             "option": "not_useful",
             "payload": action["payload"],
+            "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+            "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
         }
         response = self.client.post(
             action["url"],
@@ -769,11 +799,19 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response["X-Turn-Integration-Refresh"], "true")
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "momconnect_nonloss_optout")
-        self.assertEqual(change.data, {"reason": "not_useful"})
+        self.assertEqual(
+            change.data,
+            {
+                "reason": "not_useful",
+                "engage": {
+                    "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+                    "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
+                },
+            },
+        )
         self.assertTrue(change.validated)
 
     @responses.activate
@@ -818,6 +856,8 @@ class EngageContextViewTests(APITestCase):
             "address": "+27820001001",
             "option": "miscarriage",
             "payload": action["payload"],
+            "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+            "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
         }
         response = self.client.post(
             action["url"],
@@ -829,12 +869,20 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response["X-Turn-Integration-Refresh"], "true")
 
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "momconnect_loss_optout")
-        self.assertEqual(change.data, {"reason": "miscarriage"})
+        self.assertEqual(
+            change.data,
+            {
+                "reason": "miscarriage",
+                "engage": {
+                    "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+                    "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
+                },
+            },
+        )
         self.assertTrue(change.validated)
 
     @responses.activate
@@ -879,6 +927,8 @@ class EngageContextViewTests(APITestCase):
             "address": "+27820001001",
             "option": "miscarriage",
             "payload": action["payload"],
+            "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+            "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
         }
         response = self.client.post(
             action["url"],
@@ -890,11 +940,19 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response["X-Turn-Integration-Refresh"], "true")
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "momconnect_loss_switch")
-        self.assertEqual(change.data, {"reason": "miscarriage"})
+        self.assertEqual(
+            change.data,
+            {
+                "reason": "miscarriage",
+                "engage": {
+                    "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+                    "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
+                },
+            },
+        )
         self.assertTrue(change.validated)
 
     @responses.activate
@@ -939,6 +997,8 @@ class EngageContextViewTests(APITestCase):
             "address": "+27820001001",
             "option": "zul_ZA",
             "payload": action["payload"],
+            "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+            "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
         }
         response = self.client.post(
             action["url"],
@@ -950,9 +1010,17 @@ class EngageContextViewTests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response["X-Turn-Integration-Refresh"], "true")
         [change] = Change.objects.all()
         self.assertEqual(change.registrant_id, mother_uuid)
         self.assertEqual(change.action, "momconnect_change_language")
-        self.assertEqual(change.data, {"language": "zul_ZA"})
+        self.assertEqual(
+            change.data,
+            {
+                "language": "zul_ZA",
+                "engage": {
+                    "integration_uuid": "8cf3d402-7b25-47fd-8ef2-3e2537fccc14",
+                    "integration_action_uuid": "009d3a39-326c-42f3-af72-b5ddbece219a",
+                },
+            },
+        )
         self.assertTrue(change.validated)


### PR DESCRIPTION
Currently, we're using the X-Turn-Integration-Refresh header, which immediately refreshes the context after sending the action through to us.

The issue with this is that the action hasn't completed on our side yet, so when it refreshes it still displays the old data.

What we should instead be doing is using the "Delayed refresh" function of the API, where we call the API back with a webhook once we have finished processing the action, so that the context can be updated with the changed details