### PR TITLE
added metadata to sms outbounds for postbirth messageset

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -578,6 +578,7 @@ class ValidateImplement(Task):
                         "to_identity": change.registrant_id,
                         "content": fail_contact_check_text,
                         "channel": "JUNE_TEXT",
+                        "metadata": {},
                     }
                 )
             elif reason == "whatsapp_unsent_event":
@@ -586,6 +587,7 @@ class ValidateImplement(Task):
                         "to_identity": change.registrant_id,
                         "content": unsent_event_text,
                         "channel": "JUNE_TEXT",
+                        "metadata": {},
                     }
                 )
 

--- a/changes/tests.py
+++ b/changes/tests.py
@@ -3945,6 +3945,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
                     "To stop msgs, reply 'STOP' (std rates apply)"
                 ),
                 "channel": "JUNE_TEXT",
+                "metadata": {},
             }
         )
 
@@ -4007,6 +4008,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
                     "To stop msgs, reply 'STOP' (std rates apply)"
                 ),
                 "channel": "JUNE_TEXT",
+                "metadata": {},
             }
         )
 


### PR DESCRIPTION
In this PR, we add the metadata field to the JUNE_TEXT outbounds for the postbirth year 1-2 messageset