### PR TITLE
Fix transmission of context between tasks

### DIFF
--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -1375,7 +1375,10 @@ def update_identity_from_rapidpro_clinic_registration(context):
     else:  # registration_type == postbirth
         identity["details"]["last_baby_dob"] = context["baby_dob"]
 
-    utils.is_client.update_identity(identity["id"], {"details": identity["details"]})
+    context["mom_msisdn_identity"] = utils.is_client.update_identity(
+        identity["id"], {"details": identity["details"]}
+    )
+    return context
 
 
 @app.task(


### PR DESCRIPTION
Currently, the update identity task is not returning the context, which makes the next task, which expects the context, break.

We should fix this, but also create an end-to-end test to ensure that all the tasks are passing along data in a way that the next task understands.