### PR TITLE
Add postbirth registrations for MomConnect

### DIFF
--- a/changes/tests.py
+++ b/changes/tests.py
@@ -1816,7 +1816,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(change.validated, True)
         self.assertEqual(Registration.objects.all().count(), 2)
         self.assertEqual(SubscriptionRequest.objects.all().count(), 2)
-        self.assertEqual(len(responses.calls), 13)
+        self.assertEqual(len(responses.calls), 15)
 
         # Check Jembi POST
         self.assertEqual(
@@ -1883,7 +1883,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(change.validated, True)
         self.assertEqual(Registration.objects.all().count(), 1)
         self.assertEqual(SubscriptionRequest.objects.all().count(), 1)
-        self.assertEqual(len(responses.calls), 8)
+        self.assertEqual(len(responses.calls), 9)
 
         # Check Jembi POST
         self.assertEqual(
@@ -1954,7 +1954,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(change.validated, True)
         self.assertEqual(Registration.objects.all().count(), 1)
         self.assertEqual(SubscriptionRequest.objects.all().count(), 1)
-        self.assertEqual(len(responses.calls), 8)
+        self.assertEqual(len(responses.calls), 9)
 
         # Check Jembi POST
         self.assertEqual(
@@ -2026,7 +2026,7 @@ class TestChangeActions(AuthenticatedAPITestCase):
         self.assertEqual(change.validated, True)
         self.assertEqual(Registration.objects.all().count(), 1)
         self.assertEqual(SubscriptionRequest.objects.all().count(), 1)
-        self.assertEqual(len(responses.calls), 8)
+        self.assertEqual(len(responses.calls), 9)
 
         # Check Jembi POST
         self.assertEqual(

--- a/ndoh_hub/test_utils.py
+++ b/ndoh_hub/test_utils.py
@@ -1,0 +1,181 @@
+from unittest import TestCase
+
+import responses
+
+from ndoh_hub.utils import get_messageset_short_name, get_messageset_schedule_sequence
+from ndoh_hub.utils_tests import mock_get_messageset_by_shortname, mock_get_schedule
+
+
+class GetMessagesetShortnameTests(TestCase):
+    def test_postbirth_batch_number(self):
+        """
+        The batch number should correctly correspond with the age of the baby
+        """
+        self.assertEqual(
+            get_messageset_short_name("momconnect_postbirth", "hw_full", 0),
+            "momconnect_postbirth.hw_full.1",
+        )
+        self.assertEqual(
+            get_messageset_short_name("momconnect_postbirth", "hw_full", 14),
+            "momconnect_postbirth.hw_full.1",
+        )
+        self.assertEqual(
+            get_messageset_short_name("momconnect_postbirth", "hw_full", 15),
+            "momconnect_postbirth.hw_full.2",
+        )
+
+    def test_whatsapp_postbirth_batch_number(self):
+        """
+        The batch number should correctly correspond with the age of the baby
+        """
+        self.assertEqual(
+            get_messageset_short_name("whatsapp_postbirth", "hw_full", 0),
+            "whatsapp_momconnect_postbirth.hw_full.1",
+        )
+        self.assertEqual(
+            get_messageset_short_name("whatsapp_postbirth", "hw_full", 14),
+            "whatsapp_momconnect_postbirth.hw_full.1",
+        )
+        self.assertEqual(
+            get_messageset_short_name("whatsapp_postbirth", "hw_full", 15),
+            "whatsapp_momconnect_postbirth.hw_full.2",
+        )
+        self.assertEqual(
+            get_messageset_short_name("whatsapp_postbirth", "hw_full", 52),
+            "whatsapp_momconnect_postbirth.hw_full.2",
+        )
+        self.assertEqual(
+            get_messageset_short_name("whatsapp_postbirth", "hw_full", 53),
+            "whatsapp_momconnect_postbirth.hw_full.3",
+        )
+
+
+class GetMessagesetScheduleSequenceTests(TestCase):
+    @responses.activate
+    def test_momconnect_postbirth_1(self):
+        """
+        Should calculate the correct sequence for number of weeks
+        """
+        schedule_id = mock_get_messageset_by_shortname("momconnect_postbirth.hw_full.1")
+        mock_get_schedule(schedule_id)
+
+        self.assertEqual(
+            get_messageset_schedule_sequence("momconnect_postbirth.hw_full.1", 0),
+            (31, 131, 1),
+        )
+        self.assertEqual(
+            get_messageset_schedule_sequence("momconnect_postbirth.hw_full.1", 1),
+            (31, 131, 3),
+        )
+        self.assertEqual(
+            get_messageset_schedule_sequence("momconnect_postbirth.hw_full.1", 14),
+            (31, 131, 29),
+        )
+
+    @responses.activate
+    def test_momconnect_postbirth_2(self):
+        """
+        Should calculate the correct sequence for number of weeks
+        """
+        schedule_id = mock_get_messageset_by_shortname("momconnect_postbirth.hw_full.2")
+        mock_get_schedule(schedule_id)
+
+        self.assertEqual(
+            get_messageset_schedule_sequence("momconnect_postbirth.hw_full.2", 15),
+            (32, 132, 1),
+        )
+        self.assertEqual(
+            get_messageset_schedule_sequence("momconnect_postbirth.hw_full.2", 16),
+            (32, 132, 2),
+        )
+        self.assertEqual(
+            get_messageset_schedule_sequence("momconnect_postbirth.hw_full.2", 52),
+            (32, 132, 38),
+        )
+
+    @responses.activate
+    def test_whatsapp_momconnect_postbirth_1(self):
+        """
+        Should calculate the correct sequence for number of weeks
+        """
+        schedule_id = mock_get_messageset_by_shortname(
+            "whatsapp_momconnect_postbirth.hw_full.1"
+        )
+        mock_get_schedule(schedule_id)
+
+        self.assertEqual(
+            get_messageset_schedule_sequence(
+                "whatsapp_momconnect_postbirth.hw_full.1", 0
+            ),
+            (94, 194, 1),
+        )
+        self.assertEqual(
+            get_messageset_schedule_sequence(
+                "whatsapp_momconnect_postbirth.hw_full.1", 1
+            ),
+            (94, 194, 3),
+        )
+        self.assertEqual(
+            get_messageset_schedule_sequence(
+                "whatsapp_momconnect_postbirth.hw_full.1", 14
+            ),
+            (94, 194, 29),
+        )
+
+    @responses.activate
+    def test_whatsapp_momconnect_postbirth_2(self):
+        """
+        Should calculate the correct sequence for number of weeks
+        """
+        schedule_id = mock_get_messageset_by_shortname(
+            "whatsapp_momconnect_postbirth.hw_full.2"
+        )
+        mock_get_schedule(schedule_id)
+
+        self.assertEqual(
+            get_messageset_schedule_sequence(
+                "whatsapp_momconnect_postbirth.hw_full.2", 15
+            ),
+            (97, 197, 1),
+        )
+        self.assertEqual(
+            get_messageset_schedule_sequence(
+                "whatsapp_momconnect_postbirth.hw_full.2", 16
+            ),
+            (97, 197, 2),
+        )
+        self.assertEqual(
+            get_messageset_schedule_sequence(
+                "whatsapp_momconnect_postbirth.hw_full.2", 52
+            ),
+            (97, 197, 38),
+        )
+
+    @responses.activate
+    def test_whatsapp_momconnect_postbirth_3(self):
+        """
+        Should calculate the correct sequence for number of weeks
+        """
+        schedule_id = mock_get_messageset_by_shortname(
+            "whatsapp_momconnect_postbirth.hw_full.3"
+        )
+        mock_get_schedule(schedule_id)
+
+        self.assertEqual(
+            get_messageset_schedule_sequence(
+                "whatsapp_momconnect_postbirth.hw_full.3", 53
+            ),
+            (98, 198, 1),
+        )
+        self.assertEqual(
+            get_messageset_schedule_sequence(
+                "whatsapp_momconnect_postbirth.hw_full.3", 54
+            ),
+            (98, 198, 4),
+        )
+        self.assertEqual(
+            get_messageset_schedule_sequence(
+                "whatsapp_momconnect_postbirth.hw_full.3", 104
+            ),
+            (98, 198, 154),
+        )

--- a/ndoh_hub/test_utils.py
+++ b/ndoh_hub/test_utils.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import responses
 
-from ndoh_hub.utils import get_messageset_short_name, get_messageset_schedule_sequence
+from ndoh_hub.utils import get_messageset_schedule_sequence, get_messageset_short_name
 from ndoh_hub.utils_tests import mock_get_messageset_by_shortname, mock_get_schedule
 
 

--- a/ndoh_hub/utils.py
+++ b/ndoh_hub/utils.py
@@ -179,6 +179,8 @@ def get_messageset_short_name(reg_type, authority, weeks):
 
     if reg_type == "whatsapp_prebirth":
         reg_type = "whatsapp_momconnect_prebirth"
+    if reg_type == "whatsapp_postbirth":
+        reg_type = "whatsapp_momconnect_postbirth"
 
     if "pmtct_prebirth" in reg_type:
         if 30 <= weeks <= 34:
@@ -204,6 +206,15 @@ def get_messageset_short_name(reg_type, authority, weeks):
         else:
             batch_number = 6
 
+    elif "momconnect_postbirth" in reg_type and authority == "hw_full":
+        if weeks <= 14:
+            batch_number = 1
+        elif weeks <= 52:
+            batch_number = 2
+        elif weeks >= 53:
+            if reg_type == "whatsapp_momconnect_postbirth":
+                batch_number = 3
+
     # If the RTHB messaging is enabled, all nurseconnect subscriptions should
     # start on the RTHB messageset
     elif settings.NURSECONNECT_RTHB and "nurseconnect" in reg_type:
@@ -218,7 +229,7 @@ def get_messageset_schedule_sequence(short_name, weeks):
     # get messageset
     messageset = next(sbm_client.get_messagesets({"short_name": short_name})["results"])
 
-    if "prebirth" in short_name:
+    if "prebirth" in short_name or "postbirth" in short_name:
         # get schedule
         schedule = sbm_client.get_schedule(messageset["default_schedule"])
         # get schedule days of week: comma-seperated str e.g. '1,3' for Mon&Wed
@@ -269,6 +280,14 @@ def get_messageset_schedule_sequence(short_name, weeks):
             next_sequence_number = ((weeks - 4) // 4) + 1
 
     # other momconnect_prebirth sets start at 1
+
+    # postbirth
+    elif "momconnect_postbirth.hw_full.1" in short_name:
+        next_sequence_number = (weeks * msgs_per_week) + 1
+    elif "momconnect_postbirth.hw_full.2" in short_name:
+        next_sequence_number = (weeks - 15) * msgs_per_week + 1
+    elif short_name == "whatsapp_momconnect_postbirth.hw_full.3":
+        next_sequence_number = (weeks - 53) * msgs_per_week + 1
 
     # loss subscriptions always start at 1
 

--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -145,9 +145,11 @@ def mock_get_messageset_by_shortname(short_name):
         "whatsapp_pmtct_postbirth.patient.1": 91,
         "whatsapp_pmtct_prebirth.patient.1": 92,
         "whatsapp_momconnect_prebirth.hw_full.1": 93,
-        "whatsapp_momconnect_postbirth.hw_full.1": 93,
-        "whatsapp_momconnect_prebirth.hw_full.2": 94,
-        "whatsapp_service_info.hw_full.1": 95,
+        "whatsapp_momconnect_postbirth.hw_full.1": 94,
+        "whatsapp_momconnect_prebirth.hw_full.2": 95,
+        "whatsapp_service_info.hw_full.1": 96,
+        "whatsapp_momconnect_postbirth.hw_full.2": 97,
+        "whatsapp_momconnect_postbirth.hw_full.3": 98,
     }[short_name]
 
     default_schedule = {
@@ -178,10 +180,12 @@ def mock_get_messageset_by_shortname(short_name):
         "whatsapp_loss_miscarriage.patient.1": 181,
         "whatsapp_pmtct_postbirth.patient.1": 191,
         "whatsapp_pmtct_prebirth.patient.1": 192,
-        "whatsapp_momconnect_prebirth.hw_full.1": 192,
-        "whatsapp_momconnect_postbirth.hw_full.1": 192,
-        "whatsapp_momconnect_prebirth.hw_full.2": 122,
-        "whatsapp_service_info.hw_full.1": 123,
+        "whatsapp_momconnect_prebirth.hw_full.1": 193,
+        "whatsapp_momconnect_postbirth.hw_full.1": 194,
+        "whatsapp_momconnect_prebirth.hw_full.2": 195,
+        "whatsapp_service_info.hw_full.1": 196,
+        "whatsapp_momconnect_postbirth.hw_full.2": 197,
+        "whatsapp_momconnect_postbirth.hw_full.3": 198,
     }[short_name]
 
     responses.add(
@@ -316,6 +320,12 @@ def mock_get_schedule(schedule_id):
         181: "1,4",
         191: "1,4",
         192: "1",
+        193: "1,4",
+        194: "1,4",
+        195: "1,3,5",
+        196: "*",
+        197: "1",
+        198: "1,3,5",
     }[schedule_id]
 
     responses.add(

--- a/registrations/management/commands/tests/test_service_info_subscriptions.py
+++ b/registrations/management/commands/tests/test_service_info_subscriptions.py
@@ -124,11 +124,11 @@ class ServiceInfoSubscriptionsTests(TestCase):
         )
 
         [subreq] = SubscriptionRequest.objects.all()
-        self.assertEqual(subreq.messageset, 95)
+        self.assertEqual(subreq.messageset, 96)
         self.assertEqual(subreq.identity, "identity-uuid2")
         self.assertEqual(subreq.next_sequence_number, 1)
         self.assertEqual(subreq.lang, "sso_ZA")
-        self.assertEqual(subreq.schedule, 123)
+        self.assertEqual(subreq.schedule, 196)
 
     @responses.activate
     def test_service_info_sequence(self):

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -398,6 +398,12 @@ class ValidateSubscribe(Task):
         elif "pmtct_postbirth" in registration.reg_type:
             weeks = utils.get_baby_age(utils.get_today(), registration.data["baby_dob"])
 
+        elif (
+            registration.reg_type in ("momconnect_postbirth", "whatsapp_postbirth")
+            and registration.source.authority == "hw_full"
+        ):
+            weeks = utils.get_baby_age(utils.get_today(), registration.data["baby_dob"])
+
         # . determine messageset shortname
         self.log.info("Determining messageset shortname")
         short_name = utils.get_messageset_short_name(

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -336,15 +336,23 @@ class ValidateSubscribe(Task):
         Creates a new subscription request for the service info message set.
         This should only be created for momconnect whatsapp registrations.
         """
-        if (
-            registration.reg_type != "whatsapp_prebirth"
-            or registration.source.authority in ["hw_partial", "patient"]
-        ):
+        if registration.reg_type not in (
+            "whatsapp_prebirth",
+            "whatsapp_postbirth",
+        ) or registration.source.authority in ["hw_partial", "patient"]:
             return
 
         self.log.info("Fetching messageset")
 
-        weeks = utils.get_pregnancy_week(utils.get_today(), registration.data["edd"])
+        if registration.reg_type == "whatsapp_prebirth":
+            weeks = utils.get_pregnancy_week(
+                utils.get_today(), registration.data["edd"]
+            )
+        else:
+            weeks = (
+                utils.get_baby_age(utils.get_today(), registration.data["baby_dob"])
+                + 40
+            )
         msgset_short_name = utils.get_messageset_short_name(
             "whatsapp_service_info", registration.source.authority, weeks
         )

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -303,10 +303,12 @@ class ValidateSubscribe(Task):
         message set tells the user how to access the POPI required services.
         This should only be sent for Clinic or CHW registrations.
         """
-        if (
-            "prebirth" not in registration.reg_type
-            or registration.source.authority not in ["hw_partial", "hw_full"]
-        ):
+        if registration.reg_type not in (
+            "momconnect_prebirth",
+            "momconnect_postbirth",
+            "whatsapp_prebirth",
+            "whatsapp_postbirth",
+        ) or registration.source.authority not in ["hw_partial", "hw_full"]:
             return "POPI Subscription request not created"
 
         self.log.info("Fetching messageset")

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -259,8 +259,22 @@ class ValidateSubscribe(Task):
                 validation_errors += self.check_edd(data_fields, registration)
                 validation_errors += self.check_faccode(data_fields, registration)
 
-        elif registration.reg_type == "momconnect_postbirth":
-            validation_errors.append("Momconnect postbirth not yet supported")
+        elif registration.reg_type in ("momconnect_postbirth", "whatsapp_postbirth"):
+            if registration.source.authority == "hw_full":
+                validation_errors += self.check_operator_id(data_fields, registration)
+                validation_errors += self.check_msisdn_registrant(
+                    data_fields, registration
+                )
+                validation_errors += self.check_msisdn_device(data_fields, registration)
+                validation_errors += self.check_lang(data_fields, registration)
+                validation_errors += self.check_consent(data_fields, registration)
+                validation_errors += self.check_id(data_fields, registration)
+                validation_errors += self.check_baby_dob(data_fields, registration)
+                validation_errors += self.check_faccode(data_fields, registration)
+            else:
+                validation_errors += [
+                    "Momconnect postbirth not yet supported for public or CHW"
+                ]
 
         elif registration.reg_type == "loss_general":
             validation_errors.append("Loss general not yet supported")

--- a/registrations/test_tasks.py
+++ b/registrations/test_tasks.py
@@ -1675,3 +1675,43 @@ class ValidateSubscribePostbirthTests(AuthenticatedAPITestCase):
         )
         result = validate_subscribe.validate(registration)
         self.assertTrue(result)
+
+
+class CreatePOPISubscriptionRequestPostbirthTests(AuthenticatedAPITestCase):
+    @responses.activate
+    def test_creates_popi_subscriptionrequest_sms(self):
+        """
+        Should create a subscription request for POPI messages on SMS postbirth
+        registrations
+        """
+        utils_tests.mock_get_messageset_by_shortname("popi.hw_full.1")
+        registration = Registration.objects.create(
+            reg_type="momconnect_postbirth",
+            source=self.make_source_adminuser(),
+            registrant_id=str(uuid4()),
+            data={"language": "eng_ZA"},
+        )
+        result = validate_subscribe.create_popi_subscriptionrequest(registration)
+        self.assertEqual(result, "POPI Subscription Request created")
+        [subreq] = SubscriptionRequest.objects.all()
+        self.assertEqual(subreq.messageset, 71)
+        self.assertEqual(subreq.lang, "eng_ZA")
+
+    @responses.activate
+    def test_creates_popi_subscriptionrequest_whatsapp(self):
+        """
+        Should create a subscription request for POPI messages on WhatsApp postbirth
+        registrations
+        """
+        utils_tests.mock_get_messageset_by_shortname("popi.hw_full.1")
+        registration = Registration.objects.create(
+            reg_type="whatsapp_postbirth",
+            source=self.make_source_adminuser(),
+            registrant_id=str(uuid4()),
+            data={"language": "eng_ZA"},
+        )
+        result = validate_subscribe.create_popi_subscriptionrequest(registration)
+        self.assertEqual(result, "POPI Subscription Request created")
+        [subreq] = SubscriptionRequest.objects.all()
+        self.assertEqual(subreq.messageset, 71)
+        self.assertEqual(subreq.lang, "eng_ZA")

--- a/registrations/test_tasks.py
+++ b/registrations/test_tasks.py
@@ -1736,3 +1736,49 @@ class CreateServiceInfoSubscriptionrequestPostbirthTests(AuthenticatedAPITestCas
         self.assertEqual(subreq.messageset, 96)
         self.assertEqual(subreq.lang, "eng_ZA")
         self.assertEqual(subreq.next_sequence_number, 11)
+
+
+class CreateSubscriptionrequestsPostbirthTests(AuthenticatedAPITestCase):
+    @responses.activate
+    def test_creates_postbirth_subscriptionrequest_sms(self):
+        """
+        Should create the correct subscription request for the postbirth messageset
+        """
+        schedule = utils_tests.mock_get_messageset_by_shortname(
+            "momconnect_postbirth.hw_full.1"
+        )
+        utils_tests.mock_get_schedule(schedule)
+        registration = Registration.objects.create(
+            reg_type="momconnect_postbirth",
+            source=self.make_source_adminuser(),
+            registrant_id=str(uuid4()),
+            data={"language": "eng_ZA", "baby_dob": "2015-12-01"},
+        )
+        with mock.patch("ndoh_hub.utils.get_today", override_get_today):
+            validate_subscribe.create_subscriptionrequests(registration)
+        [subreq] = SubscriptionRequest.objects.all()
+        self.assertEqual(subreq.messageset, 31)
+        self.assertEqual(subreq.lang, "eng_ZA")
+        self.assertEqual(subreq.next_sequence_number, 9)
+
+    @responses.activate
+    def test_creates_postbirth_subscriptionrequest_whatsapp(self):
+        """
+        Should create the correct subscription request for the postbirth messageset
+        """
+        schedule = utils_tests.mock_get_messageset_by_shortname(
+            "whatsapp_momconnect_postbirth.hw_full.1"
+        )
+        utils_tests.mock_get_schedule(schedule)
+        registration = Registration.objects.create(
+            reg_type="whatsapp_postbirth",
+            source=self.make_source_adminuser(),
+            registrant_id=str(uuid4()),
+            data={"language": "eng_ZA", "baby_dob": "2015-12-01"},
+        )
+        with mock.patch("ndoh_hub.utils.get_today", override_get_today):
+            validate_subscribe.create_subscriptionrequests(registration)
+        [subreq] = SubscriptionRequest.objects.all()
+        self.assertEqual(subreq.messageset, 94)
+        self.assertEqual(subreq.lang, "eng_ZA")
+        self.assertEqual(subreq.next_sequence_number, 9)

--- a/registrations/test_tasks.py
+++ b/registrations/test_tasks.py
@@ -1135,7 +1135,7 @@ class ServiceInfoSubscriptionRequestTestCase(AuthenticatedAPITestCase):
 
         [subreq] = SubscriptionRequest.objects.all()
         self.assertEqual(subreq.identity, registration.registrant_id)
-        self.assertEqual(subreq.messageset, 95)
+        self.assertEqual(subreq.messageset, 96)
         self.assertEqual(subreq.next_sequence_number, 5)
         self.assertEqual(subreq.lang, "zul_ZA")
         self.assertEqual(subreq.schedule, schedule_id)

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -2595,10 +2595,10 @@ class TestSubscriptionRequestCreation(AuthenticatedAPITestCase):
 
         sr = SubscriptionRequest.objects.last()
         self.assertEqual(sr.identity, "mother01-63e2-4acc-9b94-26663b9bc267")
-        self.assertEqual(sr.messageset, 94)
+        self.assertEqual(sr.messageset, 95)
         self.assertEqual(sr.next_sequence_number, 4)  # ((32 - 30) * 3) - 2
         self.assertEqual(sr.lang, "eng_ZA")
-        self.assertEqual(sr.schedule, 122)
+        self.assertEqual(sr.schedule, 195)
 
     @responses.activate
     def test_src_momconnect_prebirth_public(self):


### PR DESCRIPTION
This modifies the validate_subscribe task to be able to process registrations that happen after the birth of the child.