### PR TITLE
Add view for creating public registrations from RapidPro webhooks

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -480,3 +480,17 @@ class RapidProClinicRegistrationSerializer(serializers.Serializer):
                     "baby_dob field must be supplied if registration_type is postbirth"
                 )
         return data
+
+
+class RapidProPublicRegistrationSerializer(serializers.Serializer):
+    mom_msisdn = MSISDNField(
+        country="ZA", help_text="The phone number of the mother", label="Mother MSISDN"
+    )
+    mom_lang = serializers.ChoiceField(
+        utils.LANGUAGES,
+        help_text="The language that the mother would like to receive communication in",
+        label="Mother language",
+    )
+    created = serializers.DateTimeField(
+        help_text="The timestamp when the registration was created", label="Created at"
+    )

--- a/registrations/urls.py
+++ b/registrations/urls.py
@@ -54,5 +54,10 @@ urlpatterns = [
         views.RapidProClinicRegistrationView.as_view(),
         name="rapidpro-clinic-registration",
     ),
+    path(
+        "api/v1/rapidpro/public_registration",
+        views.RapidProPublicRegistrationView.as_view(),
+        name="rapidpro-public-registration",
+    ),
     url(r"^api/v1/", include(router.urls)),
 ]


### PR DESCRIPTION
This is similar to the view for clinic registrations, but is instead focussed on public registrations