### PR TITLE
Change date format for rapidpro webhook serializer

### DIFF
--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -437,6 +437,7 @@ class DoBRapidProClinicRegistrationSerializer(serializers.Serializer):
         allow_null=True,
         help_text="When the mother was born. Required if ID type is none",
         label="Mother date of birth",
+        input_formats=["%d-%m-%Y", "iso-8601"],
     )
 
 
@@ -449,6 +450,7 @@ class PrebirthRapidProClinicRegistrationSerializer(serializers.Serializer):
         "prebirth",
         label="Mother EDD",
         validators=[validators.edd],
+        input_formats=["%d-%m-%Y", "iso-8601"],
     )
 
 
@@ -460,6 +462,7 @@ class PostBirthRapidProClinicRegistrationSerializer(serializers.Serializer):
         "years. Required if registration_type is postbirth",
         label="Mother EDD",
         validators=[validators.baby_dob],
+        input_formats=["%d-%m-%Y", "iso-8601"],
     )
 
 

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -1727,7 +1727,7 @@ class RapidProClinicRegistrationViewTests(AuthenticatedAPITestCase):
             "mom_sa_id_no": "8606045069081",
             "mom_lang": "eng_ZA",
             "registration_type": "prebirth",
-            "mom_edd": "2016-06-06",
+            "mom_edd": "06-06-2016",
             "clinic_code": "123456",
             "channel": "WhatsApp",
             "created": "2016-01-01 00:00:00",
@@ -1737,6 +1737,7 @@ class RapidProClinicRegistrationViewTests(AuthenticatedAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
         data["user_id"] = self.adminuser.id
         data["created"] = "2016-01-01T00:00:00+00:00"
+        data["mom_edd"] = "2016-06-06"
         task.delay.assert_called_once_with(data)
 
 


### PR DESCRIPTION
The `DATEVALUE` function in RapidPro returns the date in either DD-MM-YYYY or MM-DD-YYYY format, instead of the YYYY-MM-DD ISO 8601 format that we're expecting, so we have to change the serializer to accept the DD-MM-YYYY format.