### PR TITLE
Fix RapidPro subscription lookup

### DIFF
--- a/registrations/views.py
+++ b/registrations/views.py
@@ -1233,14 +1233,14 @@ class SubscriptionCheckView(APIView):
             ).latest("created_at")
             last_optout = last_optout.created_at
         except Change.DoesNotExist:
-            last_optout = datetime.datetime.min
+            last_optout = timezone.utc.localize(datetime.datetime.min)
         try:
             last_baby_switch = Change.objects.filter(
                 registrant_id=identity_id, action="baby_switch", validated=True
             ).latest("created_at")
             last_baby_switch = last_baby_switch.created_at
         except Change.DoesNotExist:
-            last_baby_switch = datetime.datetime.min
+            last_baby_switch = timezone.utc.localize(datetime.datetime.min)
 
         registrations = Registration.objects.filter(
             registrant_id=identity_id,


### PR DESCRIPTION
Currently when there are no changes, we're using `datetime.min` as the limiting timestamp. But if there is an optout, but no baby switch, that will mean that we're comparing a timezone aware timestamp with a timezone unaware one.

We should add a timezone to `datetime.min` to ensure that we're always comparing with timezones.