### PR TITLE
Add whatsapp source to authority check

### DIFF
--- a/ndoh_hub/utils_tests.py
+++ b/ndoh_hub/utils_tests.py
@@ -150,6 +150,7 @@ def mock_get_messageset_by_shortname(short_name):
         "whatsapp_service_info.hw_full.1": 96,
         "whatsapp_momconnect_postbirth.hw_full.2": 97,
         "whatsapp_momconnect_postbirth.hw_full.3": 98,
+        "whatsapp_momconnect_prebirth.patient.1": 99,
     }[short_name]
 
     default_schedule = {
@@ -186,6 +187,7 @@ def mock_get_messageset_by_shortname(short_name):
         "whatsapp_service_info.hw_full.1": 196,
         "whatsapp_momconnect_postbirth.hw_full.2": 197,
         "whatsapp_momconnect_postbirth.hw_full.3": 198,
+        "whatsapp_momconnect_prebirth.patient.1": 199,
     }[short_name]
 
     responses.add(
@@ -326,6 +328,7 @@ def mock_get_schedule(schedule_id):
         196: "*",
         197: "1",
         198: "1,3,5",
+        199: "1,3,5",
     }[schedule_id]
 
     responses.add(

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -1008,6 +1008,8 @@ class BasePushRegistrationToJembi(object):
                 "CHW USSD APP": "chw",
                 "NURSE USSD APP": "nurse",
                 "PMTCT USSD APP": "pmtct",
+                "PUBLIC WHATSAPP APP": "personal",
+                "CLINIC WHATSAPP APP": "clinic",
             }.get(source_name)
 
     def run(self, registration_id, **kwargs):

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -3377,7 +3377,7 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         )
         # Check correct type sent. 'patient' sources are sent to Jembi as type: 1
         self.assertIn("type", json.loads(jembi_call.request.body))
-        self.assertEqual(json.loads(jembi_call.request.body)['type'], 1)
+        self.assertEqual(json.loads(jembi_call.request.body)["type"], 1)
 
         post_save.disconnect(psh_validate_subscribe, sender=Registration)
 

--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -3325,6 +3325,63 @@ class TestRegistrationCreation(AuthenticatedAPITestCase):
         post_save.disconnect(psh_validate_subscribe, sender=Registration)
 
     @responses.activate
+    def test_push_registration_via_whatsapp_to_jembi(self):
+        post_save.connect(psh_validate_subscribe, sender=Registration)
+
+        # Mock API call to SBM for message set
+        schedule_id = utils_tests.mock_get_messageset_by_shortname(
+            "whatsapp_momconnect_prebirth.patient.1"
+        )
+        utils_tests.mock_get_schedule(schedule_id)
+        utils_tests.mock_get_identity_by_id("39b073a1-68b5-44e6-9b6a-db4282085c36")
+        utils_tests.mock_patch_identity("39b073a1-68b5-44e6-9b6a-db4282085c36")
+        utils_tests.mock_push_registration_to_jembi(
+            ok_response="jembi-is-ok",
+            err_response="jembi-is-unhappy",
+            fields={"cmsisdn": "+27710967611", "lang": "en"},
+        )
+        utils_tests.mock_get_identity_by_msisdn("+27710967611")
+
+        # Setup
+        source = Source.objects.create(
+            name="PUBLIC WhatsApp App",
+            authority="patient",
+            user=User.objects.get(username="testnormaluser"),
+        )
+
+        registration_data = {
+            "reg_type": "whatsapp_prebirth",
+            "registrant_id": "39b073a1-68b5-44e6-9b6a-db4282085c36",
+            "source": source,
+            "data": {
+                "operator_id": "39b073a1-68b5-44e6-9b6a-db4282085c36",
+                "edd": "2017-09-03",
+                "language": "eng_ZA",
+                "consent": True,
+                "msisdn_registrant": "+27710967611",
+                "id_type": "sa_id",
+                "faccode": "269833",
+                "msisdn_device": "+27710967611",
+                "sa_id_no": "7708050793083",
+            },
+        }
+
+        registration = Registration.objects.create(**registration_data)
+        self.assertFalse(registration.validated)
+        registration.save()
+        self.assertFalse(registration.validated)
+
+        jembi_call = responses.calls[2]  # jembi should be the third one
+        self.assertEqual(
+            json.loads(jembi_call.response.text), {"result": "jembi-is-ok"}
+        )
+        # Check correct type sent. 'patient' sources are sent to Jembi as type: 1
+        self.assertIn("type", json.loads(jembi_call.request.body))
+        self.assertEqual(json.loads(jembi_call.request.body)['type'], 1)
+
+        post_save.disconnect(psh_validate_subscribe, sender=Registration)
+
+    @responses.activate
     def test_push_external_chw_registration_to_jembi(self):
         post_save.connect(psh_validate_subscribe, sender=Registration)
 


### PR DESCRIPTION
Registrations Via Whatsapp are not being sent through to Jembi.
This PR adds the WhatsApp registration sources to the authority check so that the task doesn't fail when we try to send it to Jembi.