### PR TITLE
Use correct mha for momconnect registrations via Whatsapp

### DIFF
--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -1444,6 +1444,7 @@ def _create_rapidpro_clinic_registration(context):
         "language": context["mom_lang"],
         "faccode": context["clinic_code"],
         "consent": True,
+        "mha": 6,
     }
 
     if data["id_type"] == "sa_id":
@@ -1524,6 +1525,7 @@ def _create_rapidpro_public_registration(context):
         "language": context["mom_lang"],
         "consent": True,
         "registered_on_whatsapp": True,
+        "mha": 6,
     }
 
     Registration.objects.create(

--- a/registrations/test_tasks.py
+++ b/registrations/test_tasks.py
@@ -1422,6 +1422,7 @@ class CreateRapidProClinicRegistrationTaskTests(AuthenticatedAPITestCase):
                 "msisdn_registrant": "+27820001001",
                 "msisdn_device": "+27820001002",
                 "operator_id": "device-test-id",
+                "mha": 6,
             },
         )
 
@@ -1465,6 +1466,7 @@ class CreateRapidProClinicRegistrationTaskTests(AuthenticatedAPITestCase):
                 "msisdn_registrant": "+27820001001",
                 "msisdn_device": "+27820001002",
                 "operator_id": "device-test-id",
+                "mha": 6,
             },
         )
 
@@ -1505,6 +1507,7 @@ class CreateRapidProClinicRegistrationTaskTests(AuthenticatedAPITestCase):
                 "msisdn_registrant": "+27820001001",
                 "msisdn_device": "+27820001002",
                 "operator_id": "device-test-id",
+                "mha": 6,
             },
         )
 
@@ -1546,6 +1549,7 @@ class CreateRapidProClinicRegistrationTaskTests(AuthenticatedAPITestCase):
                 "msisdn_registrant": "+27820001001",
                 "msisdn_device": "+27820001002",
                 "operator_id": "device-test-id",
+                "mha": 6,
             },
         )
 
@@ -1605,6 +1609,7 @@ class CreateRapidProClinicRegistrationTaskTests(AuthenticatedAPITestCase):
                 "msisdn_registrant": "+27820001001",
                 "msisdn_device": "+27820001002",
                 "operator_id": "test-id-2",
+                "mha": 6,
             },
         )
 
@@ -1636,6 +1641,7 @@ class CreateRapidProPublicRegistrationTaskTests(AuthenticatedAPITestCase):
                 "msisdn_device": "+27820001001",
                 "operator_id": "test-id",
                 "registered_on_whatsapp": True,
+                "mha": 6,
             },
         )
 
@@ -1677,6 +1683,7 @@ class CreateRapidProPublicRegistrationTaskTests(AuthenticatedAPITestCase):
                 "msisdn_device": "+27820001001",
                 "operator_id": "test-id-1",
                 "registered_on_whatsapp": True,
+                "mha": 6,
             },
         )
 


### PR DESCRIPTION
We need to send mha=6 to Jembi for registrations via Whatsapp. This value is pulled from the registration data, so when we create a registration from whatsapp we need to add that value to the reg data.