### PR TITLE
Optin after registration

### DIFF
--- a/registrations/tests.py
+++ b/registrations/tests.py
@@ -725,6 +725,10 @@ class AuthenticatedAPITestCase(APITestCase):
             HTTP_AUTHORIZATION="Token %s" % self.partialtoken
         )
 
+        patcher = mock.patch("registrations.tasks.opt_in_identity")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def tearDown(self):
         self._restore_post_save_hooks()
 


### PR DESCRIPTION
Currently, if someone opts out, and then registers again, they don't get opted in again, so they don't receive any messages.

We should check if their number is opted out, and if so, opt them in again after a successful registration, to ensure that they can receive messages for their new registration.