### PR TITLE
Cache auth token lookups

### DIFF
--- a/ndoh_hub/auth.py
+++ b/ndoh_hub/auth.py
@@ -1,0 +1,16 @@
+from functools import partial
+
+from django.core.cache import caches
+from rest_framework.authentication import TokenAuthentication
+
+locmem_cache = caches["locmem"]
+
+
+class CachedTokenAuthentication(TokenAuthentication):
+    def authenticate_credentials(self, key):
+        """
+        Does a cached lookup for a user for the given token
+        """
+        return locmem_cache.get_or_set(
+            "authtoken:{}".format(key), partial(super().authenticate_credentials, key)
+        )

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -201,7 +201,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.CursorPagination",
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework.authentication.BasicAuthentication",
-        "rest_framework.authentication.TokenAuthentication",
+        "ndoh_hub.auth.CachedTokenAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
@@ -280,3 +280,8 @@ ENGAGE_HMAC_SECRET = os.environ.get("ENGAGE_HMAC_SECRET", "REPLACEME")
 ENGAGE_CONTEXT_HMAC_SECRET = os.environ.get("ENGAGE_CONTEXT_HMAC_SECRET", "REPLACEME")
 
 ENABLE_UNSENT_EVENT_ACTION = env("ENABLE_UNSENT_EVENT_ACTION")
+
+CACHES = {
+    "default": env.cache(default="locmemcache://"),
+    "locmem": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+}


### PR DESCRIPTION
This adds in-memory caching for the token + user lookup