### PR TITLE
Handle null message type when processing whatsapp messages

### DIFF
--- a/changes/tasks.py
+++ b/changes/tasks.py
@@ -1778,6 +1778,11 @@ def get_text_or_caption_from_turn_message(message: dict) -> str:
         return "<unknown>"
     except AssertionError:
         pass
+    try:
+        assert message["type"] is None
+        return "<unknown>"
+    except AssertionError:
+        pass
 
     raise ValueError("Unknown message type")
 

--- a/changes/test_tasks.py
+++ b/changes/test_tasks.py
@@ -841,6 +841,22 @@ class TestGetTextOrCaptionFromTurnMessage(TestCase):
             "<unknown>",
         )
 
+    def test_null_type(self):
+        """
+        The null message type should return <unknown>
+        """
+        self.assertEqual(
+            get_text_or_caption_from_turn_message(
+                {
+                    "from": "16315551234",
+                    "id": "ABGGFRBzFymPAgo6N9KKs7HsN6eB",
+                    "timestamp": None,
+                    "type": None,
+                }
+            ),
+            "<unknown>",
+        )
+
 
 class SendHelpdeskResponseToDHIS2Tests(DisconnectRegistrationSignalsMixin, TestCase):
     @responses.activate


### PR DESCRIPTION
For older messages, they don't have a message type, so we need to be able to handle that.