### PR TITLE
Fix submission to RP on third party registrations

### DIFF
--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -1662,13 +1662,13 @@ def submit_third_party_registration_to_rapidpro(username, data):
     if data["authority"] == "patient":
         rapidpro.create_flow_start(
             settings.RAPIDPRO_PUBLIC_REGISTRATION_FLOW,
-            urns=f"tel:{data['mom_msisdn']}",
+            urns=[f"tel:{data['mom_msisdn']}"],
             extra=registration,
         )
     elif data["authority"] == "chw":
         rapidpro.create_flow_start(
             settings.RAPIDPRO_CHW_REGISTRATION_FLOW,
-            urns=f"tel:{data['mom_msisdn']}",
+            urns=[f"tel:{data['mom_msisdn']}"],
             extra=registration,
         )
     elif data["authority"] == "clinic":
@@ -1676,6 +1676,6 @@ def submit_third_party_registration_to_rapidpro(username, data):
         registration["clinic_code"] = data["clinic_code"]
         rapidpro.create_flow_start(
             settings.RAPIDPRO_CLINIC_REGISTRATION_FLOW,
-            urns=f"tel:{data['mom_msisdn']}",
+            urns=[f"tel:{data['mom_msisdn']}"],
             extra=registration,
         )

--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -1902,7 +1902,7 @@ class ExternalRegistrationsV2Tests(APITestCase):
         self.assertEqual(
             body,
             {
-                "urns": "tel:+27820001001",
+                "urns": ["tel:+27820001001"],
                 "flow": "flow-uuid-public",
                 "extra": {
                     "language": "xh",
@@ -1942,7 +1942,7 @@ class ExternalRegistrationsV2Tests(APITestCase):
         self.assertEqual(
             body,
             {
-                "urns": "tel:+27820001001",
+                "urns": ["tel:+27820001001"],
                 "flow": "flow-uuid-chw",
                 "extra": {
                     "language": "xh",
@@ -1992,7 +1992,7 @@ class ExternalRegistrationsV2Tests(APITestCase):
         self.assertEqual(
             body,
             {
-                "urns": "tel:+27820001001",
+                "urns": ["tel:+27820001001"],
                 "flow": "flow-uuid-clinic",
                 "extra": {
                     "language": "xh",

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -435,7 +435,9 @@ class ThirdPartyRegistration(APIView):
             serializer.is_valid(raise_exception=True)
             # We encode and decode from JSON to ensure dates are encoded properly
             data = json.loads(JSONEncoder().encode(serializer.validated_data))
-            submit_third_party_registration_to_rapidpro(request.user.username, data)
+            submit_third_party_registration_to_rapidpro.delay(
+                request.user.username, data
+            )
             return Response(status=status.HTTP_202_ACCEPTED)
         else:
             return self._post(request)


### PR DESCRIPTION
The `urns` should be a list not a string, and we should also do the task in the background, not in-process