### PR TITLE
Send external ID to RapidPro for Jembi registration

### DIFF
--- a/registrations/test_views.py
+++ b/registrations/test_views.py
@@ -235,6 +235,7 @@ class JembiAppRegistrationViewTests(AuthenticatedAPITestCase):
             "flow-uuid",
             urns=["tel:+27820000000"],
             extra={
+                "external_id": "test-external-id",
                 "msisdn_registrant": "+27820000000",
                 "msisdn_device": "+27821111111",
                 "id_type": "none",

--- a/registrations/views.py
+++ b/registrations/views.py
@@ -613,7 +613,7 @@ class JembiAppRegistration(generics.CreateAPIView):
         if settings.EXTERNAL_REGISTRATIONS_V2:
             # We encode and decode from JSON to ensure dates are encoded properly
             data = json.loads(JSONEncoder().encode(serializer.validated_data))
-            external_id = data.pop("external_id", None)
+            external_id = data.get("external_id", None)
             if external_id:
                 try:
                     ExternalRegistrationID.objects.create(id=external_id)


### PR DESCRIPTION
We need this external ID for when we're doing the success/failure callbacks