### PR TITLE
Update Rapidpro preferred channel on WhatsApp inbound

### DIFF
--- a/eventstore/tasks.py
+++ b/eventstore/tasks.py
@@ -29,6 +29,18 @@ def async_create_flow_start(extra, **kwargs):
 @app.task(
     autoretry_for=(RequestException, SoftTimeLimitExceeded),
     retry_backoff=True,
+    max_retries=15,
+    acks_late=True,
+    soft_time_limit=10,
+    time_limit=15,
+)
+def update_rapidpro_contact(urn, fields):
+    rapidpro.update_contact(urn, fields=fields)
+
+
+@app.task(
+    autoretry_for=(RequestException, SoftTimeLimitExceeded),
+    retry_backoff=True,
     max_retries=1,
     acks_late=True,
     soft_time_limit=10,

--- a/eventstore/test_views.py
+++ b/eventstore/test_views.py
@@ -1036,7 +1036,8 @@ class MessagesViewSetTests(APITestCase):
 
     def test_successful_outbound_messages_on_fallback(self):
         """
-        Should create a new Outbound Message object in the database
+        Should create a new Outbound Message object in the database with the
+        fallback channel flag on
         """
         user = get_user_model().objects.create_user("test")
         user.user_permissions.add(Permission.objects.get(codename="add_message"))
@@ -1103,7 +1104,8 @@ class MessagesViewSetTests(APITestCase):
 
     def test_successful_events_request_on_fallback_channel(self):
         """
-        Should create a new Event object in the database
+        Should create a new Event object in the database with the fallback
+        channel flag on
         """
         user = get_user_model().objects.create_user("test")
         user.user_permissions.add(Permission.objects.get(codename="add_message"))

--- a/eventstore/test_whatsapp_actions.py
+++ b/eventstore/test_whatsapp_actions.py
@@ -118,11 +118,11 @@ class UpdateRapidproPreferredChannelTests(TestCase):
         message = Mock()
         message.id = "test-id"
         message.fallback_channel = True
-        message.data = {"_vnd": {"v1": {"chat": {"owner": "27820001001"}}}}
+        message.contact_id = "27820001001"
 
         with patch("eventstore.tasks.rapidpro") as p:
             update_rapidpro_preferred_channel(message)
 
         p.update_contact.assert_called_once_with(
-            "tel:+27820001001", fields={"preferred_channnel": "WhatsApp"}
+            "whatsapp:27820001001", fields={"preferred_channnel": "WhatsApp"}
         )

--- a/eventstore/whatsapp_actions.py
+++ b/eventstore/whatsapp_actions.py
@@ -37,9 +37,6 @@ def handle_inbound(message):
 
 
 def update_rapidpro_preferred_channel(message):
-    whatsapp_contact_id = message.data["_vnd"]["v1"]["chat"]["owner"]
-    msisdn = normalise_msisdn(whatsapp_contact_id)
-
     update_rapidpro_contact.delay(
-        urn=f"tel:{msisdn}", fields={"preferred_channnel": "WhatsApp"}
+        urn=f"whatsapp:{message.contact_id}", fields={"preferred_channnel": "WhatsApp"}
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ max-line-length = 88
 
 [tool:pytest]
 python_files=registrations/test*.py registrations/**/test*.py changes/test*.py changes/**/test*.py ndoh_hub/test*.py scripts/**/test*.py eventstore/test*.py
-addopts = --verbose --ds=ndoh_hub.testsettings --ignore=ve --cov=ndoh_hub --cov=registrations --cov=changes --cov=scripts --no-cov-on-fail
+addopts = --verbose --ds=ndoh_hub.testsettings --ignore=ve --cov=ndoh_hub --cov=registrations --cov=changes --cov=scripts --cov=eventstore --no-cov-on-fail
 
 [coverage:run]
 branch =True


### PR DESCRIPTION
Turn disabled the fallback flag when a user send in a WhatsApp message, this is to keep it in sync in Rapidpro.