### PR TITLE
Seed migration to RapidPro scripts

### DIFF
--- a/scripts/migrate_to_rapidpro/test_collect_information.py
+++ b/scripts/migrate_to_rapidpro/test_collect_information.py
@@ -450,19 +450,22 @@ class ProcessSubscriptionTests(TestCase):
         Should set the channel, but never overwrite WhatsApp with SMS
         """
         identities = {"identity-uuid": {"uuid": "identity-uuid"}}
+        timestamp = datetime.datetime(2020, 1, 1)
 
-        process_subscription(identities, "identity-uuid", "momconnect")
+        process_subscription(identities, "identity-uuid", "momconnect", timestamp)
         self.assertEqual(
             identities, {"identity-uuid": {"uuid": "identity-uuid", "channel": "SMS"}}
         )
 
-        process_subscription(identities, "identity-uuid", "whatsapp_momconnect")
+        process_subscription(
+            identities, "identity-uuid", "whatsapp_momconnect", timestamp
+        )
         self.assertEqual(
             identities,
             {"identity-uuid": {"uuid": "identity-uuid", "channel": "WhatsApp"}},
         )
 
-        process_subscription(identities, "identity-uuid", "momconnect")
+        process_subscription(identities, "identity-uuid", "momconnect", timestamp)
         self.assertEqual(
             identities,
             {"identity-uuid": {"uuid": "identity-uuid", "channel": "WhatsApp"}},
@@ -473,25 +476,37 @@ class ProcessSubscriptionTests(TestCase):
         Should add to the subscription list depending on the name
         """
         identities = {"identity-uuid": {"uuid": "identity-uuid"}}
+        timestamp = datetime.datetime(2020, 1, 1)
 
-        process_subscription(identities, "identity-uuid", "pmtct_prebirth.hw_full.1")
+        process_subscription(
+            identities, "identity-uuid", "pmtct_prebirth.hw_full.1", timestamp
+        )
         self.assertEqual(identities["identity-uuid"]["subscriptions"], ["PMTCT"])
 
-        process_subscription(identities, "identity-uuid", "loss_miscarriage.patient.1")
+        process_subscription(
+            identities, "identity-uuid", "loss_miscarriage.patient.1", timestamp
+        )
         self.assertEqual(
             identities["identity-uuid"]["subscriptions"], ["PMTCT", "Loss"]
         )
         self.assertEqual(identities["identity-uuid"]["optout_reason"], "miscarriage")
+        self.assertEqual(
+            identities["identity-uuid"]["optout_timestamp"], "2020-01-01T00:00:00"
+        )
 
         process_subscription(
-            identities, "identity-uuid", "momconnect_prebirth.hw_partial.1"
+            identities, "identity-uuid", "momconnect_prebirth.hw_partial.1", timestamp
         )
         self.assertEqual(
             identities["identity-uuid"]["subscriptions"], ["PMTCT", "Loss", "Public"]
         )
+        self.assertEqual(
+            identities["identity-uuid"]["public_registration_date"],
+            "2020-01-01T00:00:00",
+        )
 
         process_subscription(
-            identities, "identity-uuid", "momconnect_prebirth.hw_full.3"
+            identities, "identity-uuid", "momconnect_prebirth.hw_full.3", timestamp
         )
         self.assertEqual(
             identities["identity-uuid"]["subscriptions"],
@@ -499,14 +514,14 @@ class ProcessSubscriptionTests(TestCase):
         )
 
         process_subscription(
-            identities, "identity-uuid", "momconnect_postbirth.hw_full.2"
+            identities, "identity-uuid", "momconnect_postbirth.hw_full.2", timestamp
         )
         self.assertEqual(
             identities["identity-uuid"]["subscriptions"],
             ["PMTCT", "Loss", "Public", "Prebirth 3", "Postbirth"],
         )
 
-        process_subscription(identities, "identity-uuid", "irrelevant_name")
+        process_subscription(identities, "identity-uuid", "irrelevant_name", timestamp)
         self.assertEqual(
             identities["identity-uuid"]["subscriptions"],
             ["PMTCT", "Loss", "Public", "Prebirth 3", "Postbirth"],

--- a/scripts/migrate_to_rapidpro/test_upload_to_rapidpro.py
+++ b/scripts/migrate_to_rapidpro/test_upload_to_rapidpro.py
@@ -1,0 +1,106 @@
+from unittest import TestCase
+
+from upload_to_rapidpro import fields_from_contact
+
+
+class FieldsFromContactTests(TestCase):
+    def test_no_fields(self):
+        """
+        Should skip adding the fields if they don't exist on the contact
+        """
+        self.assertEqual(fields_from_contact({}, {}), {})
+
+    def test_field_values(self):
+        """
+        Should all all the available fields with their correct values
+        """
+        self.maxDiff = None
+        self.assertEqual(
+            fields_from_contact(
+                {
+                    k: f"{k.replace('_', '-')}-uuid"
+                    for k in [
+                        "consent",
+                        "baby_dob_1",
+                        "baby_dob_2",
+                        "baby_dob_3",
+                        "date_of_birth",
+                        "edd",
+                        "facility_code",
+                        "identification_type",
+                        "id_number",
+                        "optout_reason",
+                        "optout_timestamp",
+                        "passport_number",
+                        "passport_origin",
+                        "pmtct_risk",
+                        "preferred_channel",
+                        "public_registration_date",
+                        "registered_by",
+                    ]
+                },
+                {
+                    "consent": True,
+                    "baby_dobs": [
+                        "2020-01-01",
+                        "2020-01-01T00:00:00Z",
+                        "2019-01-01",
+                        "2018-01-01T00:00:00Z",
+                        "2017-01-01",
+                    ],
+                    "mom_dob": "1990-01-01",
+                    "edd": "2021-01-01",
+                    "faccode": "123456",
+                    "id_type": "none",
+                    "sa_id_no": "9001010000088",
+                    "optout_reason": "babyloss",
+                    "optout_timestamp": "2020-02-02",
+                    "passport_no": "A12345",
+                    "passport_origin": "zw",
+                    "pmtct_risk": "normal",
+                    "channel": "WhatsApp",
+                    "public_registration_date": "2019-02-02",
+                    "msisdn_device": "+27820001002",
+                },
+            ),
+            {
+                "consent-uuid": {"text": "TRUE"},
+                "baby-dob-1-uuid": {
+                    "datetime": "2020-01-01T00:00:00+00:00",
+                    "text": "2020-01-01T00:00:00+00:00",
+                },
+                "baby-dob-2-uuid": {
+                    "datetime": "2019-01-01T00:00:00+00:00",
+                    "text": "2019-01-01T00:00:00+00:00",
+                },
+                "baby-dob-3-uuid": {
+                    "datetime": "2018-01-01T00:00:00+00:00",
+                    "text": "2018-01-01T00:00:00+00:00",
+                },
+                "date-of-birth-uuid": {
+                    "datetime": "1990-01-01T00:00:00+00:00",
+                    "text": "1990-01-01T00:00:00+00:00",
+                },
+                "edd-uuid": {
+                    "datetime": "2021-01-01T00:00:00+00:00",
+                    "text": "2021-01-01T00:00:00+00:00",
+                },
+                "facility-code-uuid": {"text": "123456"},
+                "identification-type-uuid": {"text": "dob"},
+                "id-number-uuid": {"text": "9001010000088"},
+                "optout-reason-uuid": {"text": "babyloss"},
+                "optout-timestamp-uuid": {
+                    "datetime": "2020-02-02T00:00:00+00:00",
+                    "text": "2020-02-02T00:00:00+00:00",
+                },
+                "passport-number-uuid": {"text": "A12345"},
+                "passport-origin-uuid": {"text": "zw"},
+                "pmtct-risk-uuid": {"text": "normal"},
+                "preferred-channel-uuid": {"text": "WhatsApp"},
+                "public-registration-date-uuid": {
+                    "datetime": "2019-02-02T00:00:00+00:00",
+                    "text": "2019-02-02T00:00:00+00:00",
+                },
+                "registered-by-uuid": {"text": "+27820001002"},
+            },
+        )

--- a/scripts/migrate_to_rapidpro/test_upload_to_rapidpro.py
+++ b/scripts/migrate_to_rapidpro/test_upload_to_rapidpro.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from upload_to_rapidpro import fields_from_contact
+from .upload_to_rapidpro import fields_from_contact
 
 
 class FieldsFromContactTests(TestCase):

--- a/scripts/migrate_to_rapidpro/upload_to_rapidpro.py
+++ b/scripts/migrate_to_rapidpro/upload_to_rapidpro.py
@@ -1,0 +1,204 @@
+import json
+import time
+from datetime import datetime
+
+import psycopg2
+from django.utils.dateparse import parse_date, parse_datetime
+from psycopg2.extras import Json, execute_values
+from pytz import utc
+
+ORG = 1
+USER = 2
+
+
+def fields_from_contact(field_mapping, contact):
+    """
+    Returns the fields to insert into RapidPro given the mapping and contact
+    """
+    ret = {}
+
+    def boolean_field(field, value):
+        if contact.get(field) is True:
+            ret[field_mapping[field]] = {"text": "TRUE"}
+        elif contact.get(field) is False:
+            ret[field_mapping[field]] = {"text": "FALSE"}
+
+    def normalize_timestamp(value):
+        try:
+            return parse_datetime(value).isoformat()
+        except Exception:
+            pass
+        try:
+            value = parse_date(value)
+            value = datetime.combine(value, datetime.min.time())
+            return value.replace(tzinfo=utc).isoformat()
+        except Exception:
+            pass
+
+    def datetime_field(field, value):
+        value = normalize_timestamp(value)
+        if value:
+            ret[field_mapping[field]] = {"text": value, "datetime": value}
+
+    def string_field(field, value):
+        if value:
+            ret[field_mapping[field]] = {"text": value}
+
+    boolean_field("consent", contact.get("consent"))
+    baby_dobs = map(normalize_timestamp, contact.get("baby_dobs", []))
+    baby_dobs = sorted(set(baby_dobs), reverse=True)
+    for i, baby_dob in enumerate(baby_dobs[:3], 1):
+        datetime_field(f"baby_dob_{i}", baby_dob)
+    datetime_field("date_of_birth", contact.get("mom_dob"))
+    datetime_field("edd", contact.get("edd"))
+    string_field("facility_code", contact.get("faccode"))
+    string_field(
+        "identification_type",
+        {"sa_id": "sa_id", "passport": "passport", "none": "dob"}.get(
+            contact.get("id_type")
+        ),
+    )
+    string_field("id_number", contact.get("sa_id_no"))
+    string_field("optout_reason", contact.get("optout_reason"))
+    datetime_field("optout_timestamp", contact.get("optout_timestamp"))
+    string_field("passport_number", contact.get("passport_no"))
+    string_field("passport_origin", contact.get("passport_origin"))
+    string_field("pmtct_risk", contact.get("pmtct_risk"))
+    string_field("preferred_channel", contact.get("channel"))
+    datetime_field("public_registration_date", contact.get("public_registration_date"))
+    string_field("registered_by", contact.get("msisdn_device"))
+
+    return ret
+
+
+if __name__ == "__main__":
+    conn = psycopg2.connect(dbname="temba", user="temba", password="temba")
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT key, uuid
+        FROM contacts_contactfield
+        WHERE org_id=%s
+        """,
+        (ORG,),
+    )
+    field_mapping = dict(cursor)
+
+    cursor.execute(
+        """
+        SELECT name, id
+        FROM contacts_contactgroup
+        WHERE org_id=%s
+        """,
+        (ORG,),
+    )
+    group_mapping = dict(cursor)
+
+    cursor.execute(
+        """
+        SELECT ltrim(path, '+'), contact_id
+        FROM contacts_contacturn
+        WHERE org_id=%s
+        """,
+        (ORG,),
+    )
+    msisdn_mapping = dict(cursor)
+
+    total = 0
+    start, d_print = time.time(), time.time()
+    for l in open("results.json"):
+        contact = json.loads(l)
+        msisdn = contact["msisdn"]
+        name = (
+            f"{contact.get('mom_given_name', '')} {contact.get('mom_family_name', '')}"
+        ).strip()
+
+        contact_id = msisdn_mapping.get(msisdn.lstrip("+"))
+
+        if contact_id:
+            cursor.execute(
+                """
+                UPDATE contacts_contact
+                SET
+                    uuid=%s, name=%s, language=%s,
+                    fields=COALESCE(fields,'{}'::jsonb) || %s, modified_on=%s
+                WHERE id = %s
+                """,
+                (
+                    contact["uuid"],
+                    name or None,
+                    contact.get("language"),
+                    Json(fields_from_contact(field_mapping, contact)),
+                    datetime.now(tz=utc),
+                    contact_id,
+                ),
+            )
+        else:
+            cursor.execute(
+                """
+                INSERT INTO contacts_contact (
+                    is_active, created_on, modified_on, uuid, org_id, name, language,
+                    is_blocked, is_stopped, fields, modified_by_id, created_by_id
+                )
+                VALUES ( true, %s, %s, %s, %s, %s, %s, false, false, %s, %s, %s )
+                RETURNING
+                id
+                """,
+                (
+                    datetime.now(tz=utc),
+                    datetime.now(tz=utc),
+                    contact["uuid"],
+                    ORG,
+                    name or None,
+                    contact.get("language"),
+                    Json(fields_from_contact(field_mapping, contact)),
+                    USER,
+                    USER,
+                ),
+            )
+            [contact_id] = cursor.fetchone()
+
+        wa = msisdn.lstrip("+")
+        execute_values(
+            cursor,
+            """
+            INSERT INTO contacts_contacturn (
+                contact_id, identity, path, display, scheme, org_id, priority,
+                channel_id, auth
+            )
+            VALUES %s
+            ON CONFLICT DO NOTHING
+            """,
+            (
+                (contact_id, f"tel:{msisdn}", msisdn, None, "tel", 1, 50, None, None),
+                (contact_id, f"whatsapp:{wa}", wa, None, "whatsapp", 1, 50, None, None),
+            ),
+        )
+
+        execute_values(
+            cursor,
+            """
+            INSERT INTO contacts_contactgroup_contacts ( contactgroup_id, contact_id )
+            VALUES %s
+            ON CONFLICT DO NOTHING
+            """,
+            (
+                (group_mapping[group], contact_id)
+                for group in set(contact.get("subscriptions", []))
+            ),
+        )
+
+        if time.time() - d_print > 1:
+            print(
+                f"\rProcessed {total} identities at "
+                f"{total/(time.time() - start):.0f}/s",
+                end="",
+            )
+            d_print = time.time()
+        total += 1
+
+    print(f"\nProcessed {total} identities in {time.time() - start:.0f}s")
+
+    start = time.time()
+    conn.commit()
+    print(f"Committed changes in {time.time() - start:.0f}s")


### PR DESCRIPTION
These scripts will allow us to extract all the required information from Seed, and then upload that information to RapidPro. It does this through direct connections to the databases, for performance as well as customizability (The RapidPro API doesn't allow setting the contact UUID)