### PR TITLE
Return 200 for duplicate entries

### DIFF
--- a/eventstore/serializers.py
+++ b/eventstore/serializers.py
@@ -1,3 +1,5 @@
+import uuid
+
 from rest_framework import serializers
 
 from eventstore.models import (
@@ -114,6 +116,7 @@ class PMTCTRegistrationSerializer(BaseEventSerializer):
 
 class Covid19TriageSerializer(BaseEventSerializer):
     msisdn = MSISDNField(country="ZA")
+    deduplication_id = serializers.CharField(default=uuid.uuid4, max_length=255)
 
     class Meta:
         model = Covid19Triage

--- a/eventstore/test_views.py
+++ b/eventstore/test_views.py
@@ -1544,6 +1544,32 @@ class Covid19TriageViewSetTests(APITestCase, BaseEventTestCase):
         self.assertEqual(covid19triage.risk, Covid19Triage.RISK_LOW)
         self.assertEqual(covid19triage.created_by, user.username)
 
+    def test_duplicate_request(self):
+        """
+        Should create on the first request, and just return 200 on subsequent requests
+        """
+        user = get_user_model().objects.create_user("test")
+        user.user_permissions.add(Permission.objects.get(codename="add_covid19triage"))
+        self.client.force_authenticate(user)
+        data = {
+            "deduplication_id": "testid",
+            "msisdn": "27820001001",
+            "source": "USSD",
+            "province": "ZA-WC",
+            "city": "cape town",
+            "age": Covid19Triage.AGE_18T40,
+            "fever": False,
+            "cough": False,
+            "sore_throat": False,
+            "exposure": Covid19Triage.EXPOSURE_NO,
+            "tracing": True,
+            "risk": Covid19Triage.RISK_LOW,
+        }
+        response = self.client.post(self.url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response = self.client.post(self.url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_invalid_location_request(self):
         """
         Should create a new Covid19Triage object in the database

--- a/eventstore/views.py
+++ b/eventstore/views.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from django.conf import settings
+from django.db import IntegrityError
 from django_filters import rest_framework as filters
 from pytz import UTC
 from rest_framework import serializers, status
@@ -273,6 +274,13 @@ class Covid19TriageViewSet(GenericViewSet, CreateModelMixin, ListModelMixin):
     pagination_class = CursorPaginationFactory("timestamp")
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = Covid19TriageFilter
+
+    def create(self, *args, **kwargs):
+        try:
+            return super().create(*args, **kwargs)
+        except IntegrityError:
+            # We already have this entry
+            return Response(status=status.HTTP_200_OK)
 
 
 class CDUAddressUpdateViewSet(GenericViewSet, CreateModelMixin):


### PR DESCRIPTION
We don't want to return 400, because then it's an error that gets retried. We just want to return a 200, so that the client knows that we already have this, and can mark this as complete