### PR TITLE
Fix postbirth contacts without events

### DIFF
--- a/scripts/migrate_to_rapidpro/postbirth_contacts_without_events.py
+++ b/scripts/migrate_to_rapidpro/postbirth_contacts_without_events.py
@@ -1,0 +1,101 @@
+import datetime
+import time
+
+import iso8601
+import psycopg2
+from temba_client.v2 import TembaClient
+
+RAPIDPRO_URL = "https://rapidpro.prd.momconnect.co.za/"
+RAPIDPRO_TOKEN = ""
+
+DB = {
+    "dbname": "ndoh_rapidpro",
+    "user": "ndoh_rapidpro",
+    "port": 7000,
+    "host": "localhost",
+    "password": "",
+}
+
+
+if __name__ == "__main__":
+    rapidpro_client = TembaClient(RAPIDPRO_URL, RAPIDPRO_TOKEN)
+    conn = psycopg2.connect(**DB)
+
+    cursor = conn.cursor("contacts")
+    mapping_cursor = conn.cursor()
+
+    mapping_cursor.execute(
+        """
+        SELECT key, uuid
+        FROM contacts_contactfield
+        WHERE org_id=5
+        """
+    )
+    field_mapping = dict(mapping_cursor)
+
+    now = datetime.date.today()
+
+    print("Processing contacts...")  # noqa
+    cursor.execute(
+        """
+        SELECT
+            distinct contacts_contact.id,
+            contacts_contact.uuid,
+            contacts_contact.fields,
+            contacts_contactgroup.id,
+            contacts_contact.created_on
+        FROM contacts_contactgroup,
+            campaigns_campaign,
+            contacts_contactgroup_contacts
+                left outer join campaigns_eventfire
+                on campaigns_eventfire.contact_id =
+                    contacts_contactgroup_contacts.contact_id,
+            contacts_contact
+        WHERE contacts_contactgroup.org_id = 5
+            and contacts_contactgroup.id in (324, 325)
+        AND campaigns_campaign.group_id = contacts_contactgroup.id
+        and contacts_contactgroup_contacts.contactgroup_id = contacts_contactgroup.id
+        and campaigns_eventfire.contact_id is null
+        and contacts_contactgroup_contacts.contact_id = contacts_contact.id
+        """
+    )
+
+    total = 0
+    updated = 0
+    contact_id = 0
+
+    start, d_print = time.time(), time.time()
+    for (contact_id, contact_uuid, fields, group_id, created_on) in cursor:
+        should_receive_msgs = False
+        fields_to_update = {}
+
+        for date_field in ("baby_dob1", "baby_dob2", "baby_dob3"):
+            date_value = fields.get(field_mapping[date_field], {}).get("datetime")
+            text_value = fields.get(field_mapping[date_field], {}).get("text")
+
+            if date_value:
+                date_obj = iso8601.parse_date(date_value)
+
+                delta = datetime.date.today() - date_obj.date()
+                if delta.days <= 730:
+                    should_receive_msgs = True
+                    fields_to_update[date_field] = text_value
+
+        if should_receive_msgs:
+            updated += 1
+            rapidpro_client.update_contact(contact_uuid, fields=fields_to_update)
+
+        if time.time() - d_print > 1:
+            print(  # noqa
+                f"\rProcessed {updated}/{total} contacts at "
+                f"{total/(time.time() - start):.0f}/s - ({contact_id})",
+                end="",
+            )
+            d_print = time.time()
+
+        total += 1
+
+    print(  # noqa
+        f"\rProcessed {updated}/{total} contacts at "
+        f"{total/(time.time() - start):.0f}/s - ({contact_id})"
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,4 +19,4 @@ line_length = 88
 multi_line_output = 3
 skip = ve/
 include_trailing_comma = True
-known_third_party = attr,celery,demands,dj_database_url,django,django_filters,django_prometheus,environ,fixtures,iso639,iso6709,kombu,openpyxl,phonenumbers,pkg_resources,psycopg2,pycountry,pytest,pytz,requests,responses,rest_framework,rest_hooks,seed_services_client,setuptools,simple_history,six,sqlalchemy,structlog,temba_client,wabclient
+known_third_party = attr,celery,demands,dj_database_url,django,django_filters,django_prometheus,environ,fixtures,iso639,iso6709,iso8601,kombu,openpyxl,phonenumbers,pkg_resources,psycopg2,pycountry,pytest,pytz,requests,responses,rest_framework,rest_hooks,seed_services_client,setuptools,simple_history,six,sqlalchemy,structlog,temba_client,wabclient


### PR DESCRIPTION
This will find all contacts that belong to the postbirth groups with no events, then check if they are still supposed to receive messages, If they do, then we update the relevant fields with the same data, this triggers a re-evaluation and schedules the events.