### PR TITLE
Auto archive expired helpdesk contacts

### DIFF
--- a/eventstore/tasks.py
+++ b/eventstore/tasks.py
@@ -30,7 +30,7 @@ from eventstore.models import (
     ResearchOptinSwitch,
 )
 from ndoh_hub.celery import app
-from ndoh_hub.utils import rapidpro
+from ndoh_hub.utils import get_today, rapidpro
 from registrations.tasks import request_to_jembi_api
 
 
@@ -349,3 +349,72 @@ def mark_turn_contact_healthcheck_complete(msisdn):
         },
     )
     response.raise_for_status()
+
+
+@app.task(
+    autoretry_for=(RequestException, SoftTimeLimitExceeded),
+    retry_backoff=True,
+    max_retries=15,
+    acks_late=True,
+    soft_time_limit=10,
+    time_limit=15,
+)
+def archive_turn_conversation(urn, message_id, reason):
+    headers = {
+        "Authorization": "Bearer {}".format(settings.TURN_TOKEN),
+        "Accept": "application/vnd.v1+json",
+        "Content-Type": "application/json",
+    }
+
+    data = json.dumps({"before": message_id, "reason": reason})
+
+    r = requests.post(
+        urljoin(settings.TURN_URL, f"v1/chats/{urn}/archive"),
+        headers=headers,
+        data=data,
+    )
+    r.raise_for_status()
+
+
+@app.task(
+    autoretry_for=(RequestException, SoftTimeLimitExceeded, TembaHttpError),
+    retry_backoff=True,
+    max_retries=15,
+    acks_late=True,
+    soft_time_limit=10,
+    time_limit=15,
+)
+def handle_expired_helpdesk_contacts():
+    for contact_batch in rapidpro.get_contacts(
+        group="Waiting for helpdesk"
+    ).iterfetches(retry_on_rate_exceed=True):
+        for contact in contact_batch:
+            if contact.fields.get("helpdesk_timeout") and contact.fields.get(
+                "helpdesk_message_id"
+            ):
+                timeout_date = datetime.strptime(
+                    contact.fields["helpdesk_timeout"], "%Y-%m-%d"
+                ).date()
+
+                delta = get_today() - timeout_date
+                if delta.days > settings.HELPDESK_TIMEOUT_DAYS:
+                    update_rapidpro_contact.delay(
+                        contact.uuid,
+                        {
+                            "helpdesk_timeout": None,
+                            "wait_for_helpdesk": None,
+                            "helpdesk_message_id": None,
+                        },
+                    )
+
+                    wa_id = None
+                    for urn in contact.urns:
+                        if "whatsapp" in urn:
+                            wa_id = urn.split(":")[1]
+
+                    if wa_id:
+                        archive_turn_conversation.delay(
+                            wa_id,
+                            contact.fields["helpdesk_message_id"],
+                            f"Auto archived after {delta.days} days",
+                        )

--- a/eventstore/tasks.py
+++ b/eventstore/tasks.py
@@ -381,8 +381,8 @@ def archive_turn_conversation(urn, message_id, reason):
     retry_backoff=True,
     max_retries=15,
     acks_late=True,
-    soft_time_limit=10,
-    time_limit=15,
+    soft_time_limit=600,
+    time_limit=600,
 )
 def handle_expired_helpdesk_contacts():
     for contact_batch in rapidpro.get_contacts(

--- a/eventstore/test_tasks.py
+++ b/eventstore/test_tasks.py
@@ -132,7 +132,7 @@ class HandleOldWaitingForHelpdeskContactsTests(TestCase):
             json.loads(turn_archive.request.body),
             {
                 "before": "ABGGJ4NjeFMfAgo-sCqKaSQU4UzP",
-                "reason": f"Auto archive after 11 days",
+                "reason": f"Auto archived after 11 days",
             },
         )
 

--- a/eventstore/test_tasks.py
+++ b/eventstore/test_tasks.py
@@ -1,9 +1,15 @@
+import datetime
 import json
 
 import responses
 from django.test import TestCase, override_settings
+from temba_client.v2 import TembaClient
 
-from eventstore.tasks import mark_turn_contact_healthcheck_complete
+from eventstore import tasks
+
+
+def override_get_today():
+    return datetime.datetime.strptime("20200117", "%Y%m%d").date()
 
 
 class MarkTurnContactHealthCheckCompleteTests(TestCase):
@@ -13,7 +19,7 @@ class MarkTurnContactHealthCheckCompleteTests(TestCase):
         """
         Should not send anything if the settings aren't set
         """
-        mark_turn_contact_healthcheck_complete("+27820001001")
+        tasks.mark_turn_contact_healthcheck_complete("+27820001001")
         self.assertEqual(len(responses.calls), 0)
 
     @override_settings(HC_TURN_URL="https://turn", HC_TURN_TOKEN="token")
@@ -25,8 +31,174 @@ class MarkTurnContactHealthCheckCompleteTests(TestCase):
         responses.add(
             responses.PATCH, "https://turn/v1/contacts/27820001001/profile", json={}
         )
-        mark_turn_contact_healthcheck_complete("+27820001001")
+        tasks.mark_turn_contact_healthcheck_complete("+27820001001")
         [call] = responses.calls
         self.assertEqual(json.loads(call.request.body), {"healthcheck_completed": True})
         self.assertEqual(call.request.headers["Authorization"], "Bearer token")
         self.assertEqual(call.request.headers["Accept"], "application/vnd.v1+json")
+
+
+class HandleOldWaitingForHelpdeskContactsTests(TestCase):
+    def setUp(self):
+        tasks.get_today = override_get_today
+        tasks.rapidpro = TembaClient("textit.in", "test-token")
+
+    def add_rapidpro_contact_list_response(
+        self, contact_id, fields, urns=["whatsapp:27820001001"]
+    ):
+        responses.add(
+            responses.GET,
+            "https://textit.in/api/v2/contacts.json?group=Waiting+for+helpdesk",
+            json={
+                "results": [
+                    {
+                        "uuid": contact_id,
+                        "name": "",
+                        "language": "zul",
+                        "groups": [],
+                        "fields": fields,
+                        "blocked": False,
+                        "stopped": False,
+                        "created_on": "2015-11-11T08:30:24.922024+00:00",
+                        "modified_on": "2015-11-11T08:30:25.525936+00:00",
+                        "urns": urns,
+                    }
+                ],
+                "next": None,
+            },
+        )
+
+    def add_rapidpro_contact_update_response(
+        self, contact_id, fields, urns=["whatsapp:27820001001"]
+    ):
+        responses.add(
+            responses.POST,
+            f"https://textit.in/api/v2/contacts.json?uuid={contact_id}",
+            json={
+                "uuid": contact_id,
+                "name": "",
+                "language": "zul",
+                "groups": [],
+                "fields": fields,
+                "blocked": False,
+                "stopped": False,
+                "created_on": "2015-11-11T08:30:24.922024+00:00",
+                "modified_on": "2015-11-11T08:30:25.525936+00:00",
+                "urns": urns,
+            },
+        )
+
+    @responses.activate
+    def test_conversation_expired(self):
+
+        contact_id = "9e12d04c-af25-40b6-aa4f-57c72e8e3f91"
+
+        self.add_rapidpro_contact_list_response(
+            contact_id,
+            {
+                "helpdesk_timeout": "2020-01-06",
+                "wait_for_helpdesk": "TRUE",
+                "helpdesk_message_id": "ABGGJ4NjeFMfAgo-sCqKaSQU4UzP",
+            },
+        )
+
+        self.add_rapidpro_contact_update_response(
+            contact_id,
+            {
+                "helpdesk_timeout": None,
+                "wait_for_helpdesk": None,
+                "helpdesk_message_id": None,
+            },
+        )
+
+        responses.add(
+            responses.POST, f"http://turn/v1/chats/27820001001/archive", json={}
+        )
+
+        tasks.handle_expired_helpdesk_contacts()
+
+        [_, rapidpro_update, turn_archive] = responses.calls
+        self.assertEqual(
+            json.loads(rapidpro_update.request.body),
+            {
+                "fields": {
+                    "helpdesk_timeout": None,
+                    "wait_for_helpdesk": None,
+                    "helpdesk_message_id": None,
+                }
+            },
+        )
+        self.assertEqual(
+            json.loads(turn_archive.request.body),
+            {
+                "before": "ABGGJ4NjeFMfAgo-sCqKaSQU4UzP",
+                "reason": f"Auto archive after 11 days",
+            },
+        )
+
+    @responses.activate
+    def test_conversation_not_expired(self):
+        contact_id = "9e12d04c-af25-40b6-aa4f-57c72e8e3f91"
+
+        self.add_rapidpro_contact_list_response(
+            contact_id,
+            {
+                "helpdesk_timeout": "2020-01-09",
+                "wait_for_helpdesk": "TRUE",
+                "helpdesk_message_id": "ABGGJ4NjeFMfAgo-sCqKaSQU4UzP",
+            },
+        )
+
+        tasks.handle_expired_helpdesk_contacts()
+
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_conversation_fields_not_populated(self):
+        contact_id = "9e12d04c-af25-40b6-aa4f-57c72e8e3f91"
+
+        self.add_rapidpro_contact_list_response(
+            contact_id, {"wait_for_helpdesk": "TRUE", "helpdesk_message_id": None}
+        )
+
+        tasks.handle_expired_helpdesk_contacts()
+
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_conversation_expired_no_urn(self):
+        contact_id = "9e12d04c-af25-40b6-aa4f-57c72e8e3f91"
+
+        self.add_rapidpro_contact_list_response(
+            contact_id,
+            {
+                "helpdesk_timeout": "2020-01-06",
+                "wait_for_helpdesk": "TRUE",
+                "helpdesk_message_id": "ABGGJ4NjeFMfAgo-sCqKaSQU4UzP",
+            },
+            [],
+        )
+
+        self.add_rapidpro_contact_update_response(
+            contact_id,
+            {
+                "helpdesk_timeout": None,
+                "wait_for_helpdesk": None,
+                "helpdesk_message_id": None,
+            },
+            [],
+        )
+
+        tasks.handle_expired_helpdesk_contacts()
+
+        [_, rapidpro_update] = responses.calls
+        self.assertEqual(
+            json.loads(rapidpro_update.request.body),
+            {
+                "fields": {
+                    "helpdesk_timeout": None,
+                    "wait_for_helpdesk": None,
+                    "helpdesk_message_id": None,
+                }
+            },
+        )

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -14,6 +14,7 @@ import os
 import dj_database_url
 import django.conf.locale
 import environ
+from celery.schedules import crontab
 from kombu import Exchange, Queue
 
 env = environ.Env(ENABLE_UNSENT_EVENT_ACTION=(bool, True))
@@ -232,7 +233,7 @@ CELERY_TASK_QUEUES = (Queue("ndoh_hub", Exchange("ndoh_hub"), routing_key="ndoh_
 CELERY_TASK_ALWAYS_EAGER = False
 
 # Tell Celery where to find the tasks
-CELERY_IMPORTS = ("registrations.tasks", "changes.tasks")
+CELERY_IMPORTS = ("registrations.tasks", "changes.tasks", "eventstore.tasks")
 
 CELERY_TASK_CREATE_MISSING_QUEUES = True
 CELERY_TASK_ROUTES = {
@@ -245,6 +246,13 @@ CELERY_TASK_ROUTES = {
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ["json"]
+
+CELERYBEAT_SCHEDULE = {
+    "handle_expired_helpdesk_contacts": {
+        "task": "eventstore.tasks.handle_expired_helpdesk_contacts",
+        "schedule": crontab(minute="0", hour="3"),
+    }
+}
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
 
@@ -316,6 +324,8 @@ if ENABLE_EVENTSTORE_WHATSAPP_ACTIONS:
     RAPIDPRO_UNSENT_EVENT_FLOW = env.str("RAPIDPRO_UNSENT_EVENT_FLOW")
     RAPIDPRO_OPTOUT_FLOW = env.str("RAPIDPRO_OPTOUT_FLOW")
     RAPIDPRO_EDD_LABEL_FLOW = env.str("RAPIDPRO_EDD_LABEL_FLOW")
+
+HELPDESK_TIMEOUT_DAYS = env.int("HELPDESK_TIMEOUT_DAYS", 10)
 
 # HealthCheck
 HC_TURN_URL = env.str("HC_TURN_URL", None)

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -247,10 +247,14 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ["json"]
 
+HANDLE_EXPIRED_HELPDESK_CONTACTS_HOUR = env.str(
+    "HANDLE_EXPIRED_HELPDESK_CONTACTS_HOUR", "3"
+)
+
 CELERYBEAT_SCHEDULE = {
     "handle_expired_helpdesk_contacts": {
         "task": "eventstore.tasks.handle_expired_helpdesk_contacts",
-        "schedule": crontab(minute="0", hour="3"),
+        "schedule": crontab(minute="0", hour=HANDLE_EXPIRED_HELPDESK_CONTACTS_HOUR),
     }
 }
 


### PR DESCRIPTION
Ticket: https://praekeltorg.atlassian.net/browse/WTS-137

In rapidpro when we set the wait_for_helpdesk flag we now also set helpdesk_timeout as the current date and helpdesk_message_id as the last message received.

I also created a dynamic group in rapidpro to query.

This task will run daily and check for expired contacts and close them.

There is another ticket to bulk archive old conversations too where I will populate the 2 new fields: https://praekeltorg.atlassian.net/browse/WTS-138