### PR TITLE
Add rapidpro contact lookup

### DIFF
--- a/eventstore/tasks.py
+++ b/eventstore/tasks.py
@@ -431,6 +431,9 @@ def handle_expired_helpdesk_contacts():
 )
 def reset_delivery_failure(contact_uuid):
     contact = rapidpro.get_contacts(uuid=contact_uuid).first(retry_on_rate_exceed=True)
+    if not contact:
+        return
+
     wa_id = None
     for urn in contact.urns:
         if "whatsapp" in urn:


### PR DESCRIPTION
The contact_id field in the delivery failure table refers to a WhatsApp contact_id not a Rapidpro contact uuid, we need to do a lookup on Rapidpro the get the WhatsApp contact ID, moved to task so that in doesn't happen in request.