### PR TITLE
Fix whatsapp delivery error race condition

### DIFF
--- a/eventstore/test_whatsapp_actions.py
+++ b/eventstore/test_whatsapp_actions.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.test import TestCase as DjangoTestCase
 from django.test import override_settings
 from django.utils import timezone
+from django_redis import get_redis_connection
 from pytz import UTC
 from temba_client.v2 import TembaClient
 
@@ -441,6 +442,13 @@ class HandleEventTests(DjangoTestCase):
 
 
 class HandleWhatsappEventsTests(DjangoTestCase):
+    def setUp(self):
+        redis = get_redis_connection("redis")
+        key = f"hub_handle_whatsapp_delivery_error_27820001001"
+        redis.delete(key)
+
+        return super().setUp()
+
     @override_settings(RAPIDPRO_UNSENT_EVENT_FLOW="test-flow-uuid")
     @override_settings(ENABLE_UNSENT_EVENT_ACTION=True)
     def test_handle_whatsapp_hsm_error_successful(self):

--- a/eventstore/test_whatsapp_actions.py
+++ b/eventstore/test_whatsapp_actions.py
@@ -467,7 +467,7 @@ class HandleWhatsappEventsTests(DjangoTestCase):
             extra={
                 "popi_ussd": settings.POPI_USSD_CODE,
                 "optout_ussd": settings.OPTOUT_USSD_CODE,
-                "timestamp": 1518694700,
+                "timestamp": 1_518_694_700,
             },
             flow="test-flow-uuid",
             urns=["whatsapp:27820001001"],
@@ -496,7 +496,7 @@ class HandleWhatsappEventsTests(DjangoTestCase):
         Sends a SMS and updates the contact if the contact hasn't been sent this
         message in 30 days
         """
-        timestamp = 1543999390.069308
+        timestamp = 1_543_999_390.069_308
         mock_get_utc_now.return_value = datetime.datetime.fromtimestamp(timestamp)
 
         event = Event.objects.create()
@@ -582,7 +582,7 @@ class HandleWhatsappEventsTests(DjangoTestCase):
         Sends a SMS and updates the contact if the contact hasn't been sent this
         message in 30 days
         """
-        timestamp = 1543999390.069308
+        timestamp = 1_543_999_390.069_308
         mock_get_utc_now.return_value = datetime.datetime.fromtimestamp(timestamp)
 
         event = Event.objects.create()
@@ -669,7 +669,7 @@ class HandleWhatsappEventsTests(DjangoTestCase):
         """
         Doesn't send a SMS if contact recieved the message in the last 30 days
         """
-        timestamp = 1543999390.069308
+        timestamp = 1_543_999_390.069_308
         mock_get_utc_now.return_value = datetime.datetime.fromtimestamp(timestamp)
 
         event = Event.objects.create()
@@ -712,7 +712,7 @@ class HandleWhatsappEventsTests(DjangoTestCase):
         """
         Doesn't fail when the language is None
         """
-        timestamp = 1543999390.069308
+        timestamp = 1_543_999_390.069_308
         mock_get_utc_now.return_value = datetime.datetime.fromtimestamp(timestamp)
 
         event = Event.objects.create()
@@ -755,7 +755,7 @@ class HandleWhatsappEventsTests(DjangoTestCase):
         """
         Doesn't fail when there is no contact
         """
-        timestamp = 1543999390.069308
+        timestamp = 1_543_999_390.069_308
         mock_get_utc_now.return_value = datetime.datetime.fromtimestamp(timestamp)
 
         event = Event.objects.create()

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -306,11 +306,7 @@ ENABLE_JEMBI_EVENTS = env.bool("ENABLE_JEMBI_EVENTS", True)
 CACHES = {
     "default": env.cache(default="locmemcache://"),
     "locmem": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
-    "redis": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": REDIS_URL,
-        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
-    },
+    "redis": env.cache("REDIS_URL"),
 }
 
 EXTERNAL_REGISTRATIONS_V2 = env.bool("EXTERNAL_REGISTRATIONS_V2", False)

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -306,6 +306,11 @@ ENABLE_JEMBI_EVENTS = env.bool("ENABLE_JEMBI_EVENTS", True)
 CACHES = {
     "default": env.cache(default="locmemcache://"),
     "locmem": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+    "redis": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": REDIS_URL,
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+    },
 }
 
 EXTERNAL_REGISTRATIONS_V2 = env.bool("EXTERNAL_REGISTRATIONS_V2", False)

--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -306,7 +306,7 @@ ENABLE_JEMBI_EVENTS = env.bool("ENABLE_JEMBI_EVENTS", True)
 CACHES = {
     "default": env.cache(default="locmemcache://"),
     "locmem": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
-    "redis": env.cache("REDIS_URL"),
+    "redis": env.cache("REDIS_URL", default=REDIS_URL),
 }
 
 EXTERNAL_REGISTRATIONS_V2 = env.bool("EXTERNAL_REGISTRATIONS_V2", False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,4 +19,4 @@ line_length = 88
 multi_line_output = 3
 skip = ve/
 include_trailing_comma = True
-known_third_party = attr,celery,demands,dj_database_url,django,django_filters,django_prometheus,environ,fixtures,iso639,iso6709,iso8601,kombu,openpyxl,phonenumbers,pkg_resources,psycopg2,pycountry,pytest,pytz,requests,responses,rest_framework,rest_hooks,seed_services_client,setuptools,simple_history,six,sqlalchemy,structlog,temba_client,wabclient
+known_third_party = attr,celery,demands,dj_database_url,django,django_filters,django_prometheus,django_redis,environ,fixtures,iso639,iso6709,iso8601,kombu,openpyxl,phonenumbers,pkg_resources,psycopg2,pycountry,pytest,pytz,requests,responses,rest_framework,rest_hooks,seed_services_client,setuptools,simple_history,six,sqlalchemy,structlog,temba_client,wabclient

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
         "pycountry==19.8.18",
         "attrs",
         "iso6709==0.1.5",
+        "redis==3.5.3",
+        "django-redis==4.12.1",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
WhatsApp seems to be retrying old messages that have failed then sending the failed events in batches. Multiple of these tasks gets started at the same time before we can update the timestamp on rapidpro, this will add a lock in redis to only process one of the batch.

I wasn't able to get unit tests working