### PR TITLE
Retry task on HTTPError from turn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ logs/*.log
 *.pid
 local_settings.py
 .DS_Store
+
+scripts/exports/

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -1301,7 +1301,7 @@ http_request_with_retries = HTTPRequestWithRetries()
 
 
 @app.task(
-    autoretry_for=(RequestException, SoftTimeLimitExceeded),
+    autoretry_for=(RequestException, SoftTimeLimitExceeded, HTTPError),
     retry_backoff=True,
     max_retries=15,
     acks_late=True,

--- a/registrations/tasks.py
+++ b/registrations/tasks.py
@@ -1315,6 +1315,8 @@ def get_whatsapp_contact(msisdn):
     Args:
         msisdn (str): The MSISDN to perform the lookup for.
     """
+    if redis.get(f"wacontact:{msisdn}"):
+        return
     with redis.lock(f"wacontact:{msisdn}", timeout=10):
         # Try to get existing
         try:


### PR DESCRIPTION
Attempt to fix the LockNotOwnedError error in sentry:
https://sentry.prd.momconnect.co.za/sentry/momconnect-za-hub-registration/issues/21828/