### PR TITLE
Fix error on invalid date format in import

### DIFF
--- a/eventstore/models.py
+++ b/eventstore/models.py
@@ -839,6 +839,9 @@ class ImportRow(models.Model):
                 raise ValidationError("EDD must be between now and 9 months")
         except ValueError as e:
             raise ValidationError(f"Invalid EDD date, {str(e)}")
+        except TypeError:
+            # Should be handled by the individual field validator
+            pass
 
         if self.id_type == self.IDType.SAID and not self.id_number:
             raise ValidationError("ID number required for SA ID ID type")

--- a/eventstore/test_forms.py
+++ b/eventstore/test_forms.py
@@ -296,6 +296,20 @@ class MomConnectImportFormTests(TestCase):
             "Failed validation: Invalid EDD date, day is out of range for month",
         )
 
+        file = SimpleUploadedFile(
+            "test.csv",
+            b"msisdn,facility code,id type,id number,messaging consent,"
+            b"edd year,edd month,edd day\n"
+            b"+27820001001,123456,said,9001010001088,true,2021,Feb,20\n",
+        )
+        form = MomConnectImportForm(data={}, files={"file": file})
+        instance = form.save()
+        self.assertEqual(instance.status, MomConnectImport.Status.ERROR)
+        [error] = instance.errors.all()
+        self.assertEqual(
+            error.error, "Field edd_month failed validation: Enter a whole number."
+        )
+
         self.is_valid_edd_date.return_value = False
         file = SimpleUploadedFile(
             "test.csv",


### PR DESCRIPTION
Previously it would break the import, and return a 500 error. Now we properly catch the error, and ensure that it gets written to the import error log instead