### PR TITLE
Update serializer validation

### DIFF
--- a/mqr/serializers.py
+++ b/mqr/serializers.py
@@ -17,7 +17,7 @@ class NextMessageSerializer(BaseMessageSerializer):
     subscription_type = serializers.CharField(required=True)
     arm = serializers.CharField(required=True)
     mom_name = serializers.CharField(required=True)
-    sequence = serializers.CharField(required=False)
+    sequence = serializers.CharField(required=False, allow_blank=True)
 
 
 class FaqSerializer(BaseMessageSerializer):

--- a/mqr/tests/test_views.py
+++ b/mqr/tests/test_views.py
@@ -61,6 +61,7 @@ class NextMessageViewTests(APITestCase):
                 "mom_name": "Test",
                 "contact_uuid": contact_uuid,
                 "run_uuid": run_uuid,
+                "sequence": "",
             },
         )
 
@@ -83,7 +84,7 @@ class NextMessageViewTests(APITestCase):
         }
 
         mock_get_next_message.assert_called_with(
-            datetime.date(2022, 7, 12), "PRE", "BCM", None, "Test", mock_tracking_data
+            datetime.date(2022, 7, 12), "PRE", "BCM", "", "Test", mock_tracking_data
         )
 
     @patch("mqr.views.get_next_message")


### PR DESCRIPTION
allow blank for sequence to make rapidpro api call simpler 