### PR TITLE
Remove find part for main menu faqs

### DIFF
--- a/mqr/tests/test_views.py
+++ b/mqr/tests/test_views.py
@@ -222,7 +222,7 @@ class FaqMenuViewTests(APITestCase):
             },
         )
 
-        mock_get_faq_menu.assert_called_with("rcm_week_pre22", [], True, 1)
+        mock_get_faq_menu.assert_called_with("rcm_week_pre22", [], False, 1)
 
 
 def override_get_today():

--- a/mqr/views.py
+++ b/mqr/views.py
@@ -143,10 +143,9 @@ class FaqMenuView(generics.GenericAPIView):
         tag = serializer.validated_data.get("tag").lower()
         menu_offset = serializer.validated_data.get("menu_offset", 0)
 
-        bcm = "_bcm_" in tag
         tag = tag.replace("_bcm_", "_")
 
-        menu, faq_numbers = get_faq_menu(tag, [], bcm, menu_offset)
+        menu, faq_numbers = get_faq_menu(tag, [], False, menu_offset)
 
         response = {"menu": menu, "faq_numbers": faq_numbers}
 


### PR DESCRIPTION
We don't want to add the FIND part to the bottom of the suggested FAQs for the main menu because its already there.