### PR TITLE
seperate option number from text and add error key

### DIFF
--- a/ada/serializers.py
+++ b/ada/serializers.py
@@ -19,7 +19,7 @@ class AdaInputTypeSerializer(serializers.Serializer):
                     "We are sorry, your reply should be between "
                     "*1* and *100* characters.\n\n"
                 )
-                data["message"] = f"{error}{data['message']}"
+                data["error"] = error
                 raise serializers.ValidationError(data)
             has_numbers = any(i.isdigit() for i in user_input)
             if format == "string":
@@ -29,7 +29,7 @@ class AdaInputTypeSerializer(serializers.Serializer):
                         "We are sorry, you entered a number. "
                         "Please reply with text.\n\n"
                     )
-                    data["message"] = f"{error}{data['message']}"
+                    data["error"] = error
                     raise serializers.ValidationError(data)
             elif format == "integer":
                 only_numbers = user_input.isdecimal()
@@ -38,7 +38,7 @@ class AdaInputTypeSerializer(serializers.Serializer):
                         "We are sorry, you entered text. "
                         "Please reply with a number.\n\n"
                     )
-                    data["message"] = f"{error}{data['message']}"
+                    data["error"] = error
                     raise serializers.ValidationError(data)
         return data
 
@@ -49,7 +49,7 @@ class AdaTextTypeSerializer(serializers.Serializer):
         user_input = data["value"].upper()
         if user_input not in keywords:
             error = "Please reply *continue*, *0* or *accept* to continue.\n\n"
-            data["message"] = f"{error}{data['message']}"
+            data["error"] = error
             raise serializers.ValidationError(data)
         return data
 
@@ -69,22 +69,20 @@ class AdaChoiceTypeSerializer(serializers.Serializer):
                 int(user_input)
             except ValueError:
                 error = "Please reply with the number that matches your answer.\n\n"
-                data["message"] = f"{error}{data['message']}"
-                raise serializers.ValidationError(data)
+                data["error"] = error
             if not (0 <= int(user_input) <= choices):
                 error = (
                     f"Something seems to have gone wrong. You entered "
                     f"{user_input} but there are only {choices} options. "
                     f"Please reply with a number between 1 and {choices}."
                 )
-                data["message"] = f"{error} {data['message']}"
-                raise serializers.ValidationError(data)
+                data["error"] = error
             if int(user_input) < 1:
                 error = (
                     f"Something seems to have gone wrong. You entered "
                     f"{user_input}. Please select the option that "
                     f"matches your answer."
                 )
-                data["message"] = f"{error} {data['message']}"
-                raise serializers.ValidationError(data)
+                data["error"] = error
+            raise serializers.ValidationError(data)
         return data

--- a/ada/test_utils.py
+++ b/ada/test_utils.py
@@ -174,7 +174,7 @@ class TestQuestionsPayload(TestCase):
                     "Hi John, what is your biological sex?"
                     "\nBiological sex is a risk factor for some "
                     "conditions. Your answer is necessary for an "
-                    "accurate assessment.\n\n1.Female\n2.Male\n\nChoose "
+                    "accurate assessment.\n\n1. Female\n2. Male\n\nChoose "
                     "the option that matches your answer. Eg, *1* for "
                     "*Female*\n\nReply *back* to go to the previous "
                     "question or *menu* to end the assessment."

--- a/ada/tests_views.py
+++ b/ada/tests_views.py
@@ -194,8 +194,6 @@ class AdaValidationViewTests(APITestCase):
             {
                 "msisdn": "27856454612",
                 "message": (
-                    "We are sorry, your reply should be "
-                    "between *1* and *100* characters.\n\n"
                     "Please type in the symptom that is troubling you, "
                     "only one symptom at a time. Reply back to go to the "
                     "previous question or menu to end the assessment."
@@ -211,6 +209,10 @@ class AdaValidationViewTests(APITestCase):
                 "cardType": "INPUT",
                 "title": "SYMPTOM",
                 "formatType": "string",
+                "error": (
+                    "We are sorry, your reply should be "
+                    "between *1* and *100* characters.\n\n"
+                ),
             },
             response.json(),
         )
@@ -244,10 +246,9 @@ class AdaValidationViewTests(APITestCase):
             {
                 "msisdn": "27856454612",
                 "message": (
-                    "We are sorry, you entered a number. "
-                    "Please reply with text.\n\nPlease "
-                    "type in the symptom that is troubling "
-                    "you, only one symptom at a time. "
+                    "Please type in the symptom "
+                    "that is troubling you, "
+                    "only one symptom at a time. "
                     "Reply back to go to the previous "
                     "question or menu to end the assessment."
                 ),
@@ -258,6 +259,9 @@ class AdaValidationViewTests(APITestCase):
                 "cardType": "INPUT",
                 "title": "SYMPTOM",
                 "formatType": "string",
+                "error": (
+                    "We are sorry, you entered a number. " "Please reply with text.\n\n"
+                ),
             },
             response.json(),
         )
@@ -286,10 +290,7 @@ class AdaValidationViewTests(APITestCase):
             response.json(),
             {
                 "msisdn": "27856454612",
-                "message": (
-                    "We are sorry, you entered text. "
-                    "Please reply with a number.\n\nEnter age in years"
-                ),
+                "message": ("Enter age in years"),
                 "step": "4",
                 "value": "I am 18 years old",
                 "optionId": "8",
@@ -297,6 +298,9 @@ class AdaValidationViewTests(APITestCase):
                 "cardType": "INPUT",
                 "title": "SYMPTOM",
                 "formatType": "integer",
+                "error": (
+                    "We are sorry, you entered text. " "Please reply with a number.\n\n"
+                ),
             },
             response.json(),
         )
@@ -340,9 +344,6 @@ class AdaValidationViewTests(APITestCase):
                 "choices": "3",
                 "choiceContext": ["Abdominal pain", "Headache"],
                 "message": (
-                    "Something seems to have gone wrong. You "
-                    "entered 9 but there are only 3 options. "
-                    "Please reply with a number between 1 and 3. "
                     "What is the issue?\n\nAbdominal pain\nHeadache"
                     "\nNone of these\n\nChoose the option that "
                     "matches your answer. "
@@ -356,6 +357,11 @@ class AdaValidationViewTests(APITestCase):
                 "path": "/assessments/assessment-id/dialog/next",
                 "cardType": "CHOICE",
                 "title": "SYMPTOM",
+                "error": (
+                    "Something seems to have gone wrong. You "
+                    "entered 9 but there are only 3 options. "
+                    "Please reply with a number between 1 and 3."
+                ),
             },
             response.json(),
         )
@@ -392,7 +398,6 @@ class AdaValidationViewTests(APITestCase):
                 "msisdn": "27856454612",
                 "choices": "None",
                 "message": (
-                    "Please reply *continue*, *0* or *accept* to continue.\n\n"
                     "Welcome to the MomConnect Symptom Checker in "
                     "partnership with Ada. Let's start with some questions "
                     "about the symptoms. Then, we will help you "
@@ -404,6 +409,7 @@ class AdaValidationViewTests(APITestCase):
                 "path": "/assessments/assessment-id/dialog/next",
                 "cardType": "TEXT",
                 "title": "WELCOME",
+                "error": "Please reply *continue*, *0* or *accept* to continue.\n\n",
             },
             response.json(),
         )

--- a/ada/utils.py
+++ b/ada/utils.py
@@ -127,7 +127,7 @@ def format_message(body):
             index += 1
         choiceContext = optionslist[:]
         for i in range(len(optionslist)):
-            optionslist[i] = f"{i+1}.{optionslist[i]}"
+            optionslist[i] = f"{i+1}. {optionslist[i]}"
 
         choices = "\n".join(optionslist)
         extra_message = (


### PR DESCRIPTION
This pr does the follwing:

Adds a space between option number and text. 
So instead of,
1.Male
2.Female

We now have,
1. Male
2. Female

Secondly, it removes the error message from the message body and sends that to Rapidpro as a separate key value pair to fix the issue in this ticket:  https://praekeltorg.atlassian.net/browse/AH-199

