### PR TITLE
Add placeholder text if it's available and reject 0 reply for choice cardType

### DIFF
--- a/ada/serializers.py
+++ b/ada/serializers.py
@@ -59,17 +59,18 @@ class StartAssessmentSerializer(serializers.Serializer):
 
 class AdaChoiceTypeSerializer(serializers.Serializer):
     def validate_value(self, data):
+
         user_input = data["value"].upper()
         choices = data["choices"]
         keywords = assessmentkeywords()
-        if user_input not in keywords:
+        if user_input not in keywords or data["cardType"] != "TEXT":
             try:
                 int(user_input)
             except ValueError:
                 error = "Please reply with the number that matches your answer."
                 data["error"] = error
                 raise serializers.ValidationError(data)
-            if not (0 <= int(user_input) <= choices):
+            if not (0 < int(user_input) <= choices):
                 error = (
                     f"Something seems to have gone wrong. You entered "
                     f"{user_input} but there are only {choices} options. "

--- a/ada/test_utils.py
+++ b/ada/test_utils.py
@@ -282,7 +282,9 @@ class TestQuestionsPayload(TestCase):
                 "choices": None,
                 "formatType": "integer",
                 "message": (
-                    "How old are you?\n\nReply *back* to go to "
+                    "How old are you?\n\n"
+                    'Enter age in years, for example "20"\n\n'
+                    "Reply *back* to go to "
                     "the previous question or *menu* to "
                     "end the assessment."
                 ),

--- a/ada/tests_views.py
+++ b/ada/tests_views.py
@@ -366,6 +366,61 @@ class AdaValidationViewTests(APITestCase):
             response.json(),
         )
 
+        response = self.client.post(
+            self.url,
+            json.dumps(
+                {
+                    "msisdn": "27856454612",
+                    "choices": 3,
+                    "choiceContext": ["Abdominal pain", "Headache"],
+                    "message": (
+                        "What is the issue?\n\nAbdominal pain\n"
+                        "Headache"
+                        "\nNone of these\n\nChoose the option that matches "
+                        "your answer. "
+                        "Eg, *1* for *Abdominal pain*\n\nEnter *back* to go "
+                        "to the previous question or *menu* "
+                        "to end the assessment."
+                    ),
+                    "step": 4,
+                    "value": "0",
+                    "optionId": 0,
+                    "path": "/assessments/assessment-id/dialog/next",
+                    "cardType": "CHOICE",
+                    "title": "SYMPTOM",
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(
+            response.json(),
+            {
+                "msisdn": "27856454612",
+                "choices": "3",
+                "choiceContext": ["Abdominal pain", "Headache"],
+                "message": (
+                    "What is the issue?\n\nAbdominal pain\nHeadache"
+                    "\nNone of these\n\nChoose the option that "
+                    "matches your answer. "
+                    "Eg, *1* for *Abdominal pain*\n\nEnter *back* to go "
+                    "to the previous question or *menu* "
+                    "to end the assessment."
+                ),
+                "step": "4",
+                "value": "0",
+                "optionId": "0",
+                "path": "/assessments/assessment-id/dialog/next",
+                "cardType": "CHOICE",
+                "title": "SYMPTOM",
+                "error": (
+                    "Something seems to have gone wrong. You "
+                    "entered 0 but there are only 3 options. "
+                    "Please reply with a number between 1 and 3."
+                ),
+            },
+            response.json(),
+        )
+
     # Return validation error for invalid choice for text cardType
     def test_text_type(self):
         user = get_user_model().objects.create_user("test")

--- a/ada/utils.py
+++ b/ada/utils.py
@@ -118,7 +118,8 @@ def format_message(body):
         message = f"{description}\n\n{textcontinue}\n\n{back}"
         body = {}
     else:
-        message = f"{description}\n\n{back}"
+        placeholder = body["cardAttributes"]["placeholder"]["en-GB"]
+        message = f"{description}\n\n{placeholder}\n\n{back}"
         format = body["cardAttributes"]["format"]
         body = {}
         body["choices"] = None


### PR DESCRIPTION
Adds placeholder text to message the user sees. 

Return an error if the user replies '0' for choice cardType questions. It should be for just TEXT cardType questions.