### PR TITLE
Symptom check noise

### DIFF
--- a/ada/tests_views.py
+++ b/ada/tests_views.py
@@ -127,8 +127,19 @@ class AdaSymptomCheckEndpointTests(APITestCase):
         mock_start_rapidpro_flow.delay.assert_not_called()
 
     @patch("ada.views.start_prototype_survey_flow")
+    def test_unsuccessful_flow_start(self, mock_start_rapidpro_flow):
+        whatsappid = "endToEndTestWhatsappid"
+
+        user = get_user_model().objects.create_user("test")
+        self.client.force_authenticate(user)
+        response = self.client.post(self.url, {"whatsappid": whatsappid})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        mock_start_rapidpro_flow.delay.assert_not_called()
+
+    @patch("ada.views.start_prototype_survey_flow")
     def test_successful_flow_start(self, mock_start_rapidpro_flow):
-        whatsappid = "12345"
+        whatsappid = "+274844444444"
 
         user = get_user_model().objects.create_user("test")
         self.client.force_authenticate(user)

--- a/ada/views.py
+++ b/ada/views.py
@@ -53,7 +53,7 @@ class RapidProStartFlowView(generics.GenericAPIView):
         match = re.match(
             (
                 r"^\s*(?:\+?(\d{1,3}))?[-. (]*(\d{3})[-. )]"
-                "*(\d{3})[-. ]*(\d{4})(?: *x(\d+))?\s*$"
+                r"*(\d{3})[-. ]*(\d{4})(?: *x(\d+))?\s*$"
             ),
             whatsappid,
         )

--- a/ada/views.py
+++ b/ada/views.py
@@ -1,4 +1,5 @@
 import json
+import re
 import urllib.parse
 from urllib.parse import urlencode
 
@@ -49,8 +50,15 @@ class RapidProStartFlowView(generics.GenericAPIView):
         serializer.is_valid(raise_exception=True)
 
         whatsappid = serializer.validated_data.get("whatsappid")
-
-        start_prototype_survey_flow.delay(str(whatsappid))
+        match = re.match(
+            (
+                r"^\s*(?:\+?(\d{1,3}))?[-. (]*(\d{3})[-. )]"
+                "*(\d{3})[-. ]*(\d{4})(?: *x(\d+))?\s*$"
+            ),
+            whatsappid,
+        )
+        if match:
+            start_prototype_survey_flow.delay(str(whatsappid))
 
         return Response({}, status=status.HTTP_200_OK)
 

--- a/mqr/tests/test_utils.py
+++ b/mqr/tests/test_utils.py
@@ -59,7 +59,7 @@ class TestGetTag(TestCase):
         self.assertEqual(utils.get_tag("RCM", "pre", edd), "rcm_week_pre5")
 
         few_weeks_ago = datetime.today().date() - timedelta(days=23)
-        self.assertEqual(utils.get_tag("BCM", "post", few_weeks_ago), "bcm_week_post16")
+        self.assertEqual(utils.get_tag("BCM", "post", few_weeks_ago), "bcm_week_post17")
 
     def test_get_tag_with_sequence(self):
         """
@@ -67,11 +67,11 @@ class TestGetTag(TestCase):
         """
         self.assertEqual(
             utils.get_tag("RCM", "pre", datetime.today().date(), "a"),
-            "rcm_week_pre21_a",
+            "rcm_week_pre19_a",
         )
 
         few_weeks_ago = datetime.today().date() - timedelta(days=23)
-        self.assertEqual(utils.get_tag("BCM", "post", few_weeks_ago), "bcm_week_post16")
+        self.assertEqual(utils.get_tag("BCM", "post", few_weeks_ago), "bcm_week_post17")
 
 
 class TestGetMessage(TestCase):


### PR DESCRIPTION
We sometimes get requests from ADA with Whatsappid "endToEndTestWhatsappid". 
Because it's invalid the app throws an error when trying to start a flow with it and this causes noise on Slack.
It's the old symptom checker which should have been decommissioned on ADA's side. 