### PR TITLE
remove payload key

### DIFF
--- a/ada/views.py
+++ b/ada/views.py
@@ -122,7 +122,7 @@ class Covid(generics.GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         body = request.data
-        resource_id = body["payload"]["id"]
+        resource_id = body["id"]
         store_url_entry = CovidDataLakeEntry(resource_id=resource_id, data=body)
         store_url_entry.save()
         return Response({}, status=status.HTTP_200_OK)


### PR DESCRIPTION
Related to this PR: 
https://github.com/praekeltfoundation/ndoh-hub/pull/520

Payload from ADA will now look this:
{
     "resourceType":"Bundle",
     "id":"16c905ae4f86774109062e204aca95fe",
     "meta":{
     "lastUpdated":"2022-07-21T10:19:29.140+00:00",
     "type":"document"
    }
}

Instead of this:
{
     payload: {
     "resourceType":"Bundle",
     "id":"16c905ae4f86774109062e204aca95fe",
     "meta":{
     "lastUpdated":"2022-07-21T10:19:29.140+00:00",
     "type":"document"
     }
   }
}

