### PR TITLE
Handle timeouts

### DIFF
--- a/ada/tests_views.py
+++ b/ada/tests_views.py
@@ -1022,8 +1022,6 @@ class AdaAssessmentDialog(APITestCase):
             ),
             target_status_code=410,
         )
-        response = self.client.get(self.data_next_dialog, format="json")
-        self.assertEqual(response.status_code, status.HTTP_410_GONE)
 
 
 class AdaAssessmentReport(APITestCase):

--- a/ada/tests_views.py
+++ b/ada/tests_views.py
@@ -989,6 +989,42 @@ class AdaAssessmentDialog(APITestCase):
             message,
         )
 
+    @patch("ada.views.post_to_ada")
+    def test_timeout(self, mock_post_to_ada):
+        request = utils.build_rp_request(self.data_next_dialog)
+        self.assertEqual(request, {"step": 5, "value": "27"})
+
+        mock_post_to_ada.return_value = 410
+        user = get_user_model().objects.create_user("test")
+        self.client.force_authenticate(user)
+        response = self.client.post(
+            self.entry_url, self.data_next_dialog, format="json"
+        )
+        self.assertRedirects(
+            response,
+            (
+                "/api/v2/ada/nextdialog?contact_uuid="
+                "67460e74-02e3-11e8-b443-"
+                "00163e990bdb&msisdn=27856454612&"
+                "choiceContext=&choices=None&message="
+                "How+old+are+you%3F%0A%0AReply+%2ABACK%"
+                "2A+to+go+to+the+previous+question+or+%"
+                "2AMENU%2A+to+end+the+assessment&"
+                "explanations=&step=5&value=27&optionId="
+                "None&path=%2Fassessments%2Ff9d4be32-78fa-"
+                "48e0-b9a3-e12e305e73ce%2Fdialog%2Fnext&"
+                "cardType=INPUT&title=Patient+Information&"
+                "description=How+old+are+you%3F&formatType="
+                "integer&max=120&max_error=Age+must+be+120+"
+                "years+or+younger+to+assess+the+symptoms&min="
+                "1&min_error=Age+in+years+must+be+greater+"
+                "than+0+to+assess+the+symptoms&pattern="
+            ),
+            target_status_code=410,
+        )
+        response = self.client.get(self.data_next_dialog, format="json")
+        self.assertEqual(response.status_code, status.HTTP_410_GONE)
+
 
 class AdaAssessmentReport(APITestCase):
     maxDiff = None

--- a/ada/utils.py
+++ b/ada/utils.py
@@ -112,6 +112,8 @@ def post_to_ada(body, path, contact_uuid):
     head = get_header(contact_uuid)
     path = urljoin(settings.ADA_START_ASSESSMENT_URL, path)
     response = requests.post(path, json=body, headers=head)
+    if response.status_code == 410:
+        return response.status_code
     response.raise_for_status()
     response = response.json()
     return response

--- a/ada/views.py
+++ b/ada/views.py
@@ -195,6 +195,8 @@ class NextDialog(generics.GenericAPIView):
         assessment_id = path.split("/")[-3]
         request = build_rp_request(data)
         ada_response = post_to_ada(request, path, contact_uuid)
+        if ada_response == 410:
+            return Response("Timeout", status=status.HTTP_410_GONE)
         pdf = pdf_ready(ada_response)
         if pdf:
             report_path = ada_response["_links"]["report"]["href"]


### PR DESCRIPTION
Contacts have around 2hrs to complete an assessment after which ADA returns a 410.
At the moment this throws a HTTPError in Sentry and then slack #momconnectmonitoring

These alerts are not necessary since there's nothing we can do about it. 
This pr should stop the noise in slack since 410 HTTPError's will no longer fire.