### PR TITLE
Rename assessment report

### DIFF
--- a/ada/test_utils.py
+++ b/ada/test_utils.py
@@ -624,3 +624,9 @@ class TestSubmitCastorData(TestCase):
 
         self.assertEqual(call.request.headers["Authorization"], "Bearer token-uuid")
         self.assertEqual(json.loads(call.request.body), {"field_value": "field-value"})
+
+
+class TestCleanFilename(TestCase):
+    def test_clean_filename(self):
+        file_name = utils.clean_filename("7566422 0001 0001'#{ report.json")
+        self.assertEqual(file_name, "7566422_0001_0001_report.json")

--- a/ada/utils.py
+++ b/ada/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division
 
 import json
 import posixpath
+import re
 import tempfile
 import urllib.parse
 from urllib.parse import urlencode, urljoin
@@ -341,6 +342,7 @@ def upload_edc_media(report, study_id, record_id, field_id, token):
     field_id = field_id
     path = posixpath.join(study_id, record, record_id, study_data_point, field_id)
     report_name = record_id + "_" + "report"
+    report_name = clean_filename(report_name)
     url = urljoin(settings.ADA_EDC_STUDY_URL, path)
     nullValues = json.dumps(report, indent=2).replace("null", "None")
     tobyte = nullValues.encode("utf-8")
@@ -437,3 +439,8 @@ def submit_castor_data(token, record_id, field, value):
         f"{settings.ADA_EDC_STUDY_ID}/record/{record_id}/study-data-point/{field}",
     )
     requests.post(path, json=data, headers=headers)
+
+
+def clean_filename(file_name):
+    file_name = str(file_name).strip().replace(" ", "_")
+    return re.sub(r"(?u)[^-\w.]", "", file_name)

--- a/ada/utils.py
+++ b/ada/utils.py
@@ -341,7 +341,7 @@ def upload_edc_media(report, study_id, record_id, field_id, token):
     study_data_point = "study-data-point"
     field_id = field_id
     path = posixpath.join(study_id, record, record_id, study_data_point, field_id)
-    report_name = record_id + "_" + "report"
+    report_name = record_id + "_" + "report.json"
     report_name = clean_filename(report_name)
     url = urljoin(settings.ADA_EDC_STUDY_URL, path)
     nullValues = json.dumps(report, indent=2).replace("null", "None")

--- a/ada/utils.py
+++ b/ada/utils.py
@@ -340,6 +340,7 @@ def upload_edc_media(report, study_id, record_id, field_id, token):
     study_data_point = "study-data-point"
     field_id = field_id
     path = posixpath.join(study_id, record, record_id, study_data_point, field_id)
+    report_name = record_id + "_" + "report"
     url = urljoin(settings.ADA_EDC_STUDY_URL, path)
     nullValues = json.dumps(report, indent=2).replace("null", "None")
     tobyte = nullValues.encode("utf-8")
@@ -351,7 +352,7 @@ def upload_edc_media(report, study_id, record_id, field_id, token):
     response = requests.post(
         url,
         files={
-            "upload_file": ("report.json", open(report_file, "rb"), "application/pdf")
+            "upload_file": (report_name, open(report_file, "rb"), "application/pdf")
         },
         headers=headers,
     )


### PR DESCRIPTION
Rename file name to "{record_id}_report" from "report" so it's easier to sort. 