### PR TITLE
Increment failure count for specific error codes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,14 +24,14 @@ jobs:
     env:
       HUB_DATABASE: postgres://postgres:postgres@localhost:5432/ndoh_hub
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install gettext
         run: sudo apt-get install gettext
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}-pip
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependancies

--- a/eventstore/tests/test_whatsapp_actions.py
+++ b/eventstore/tests/test_whatsapp_actions.py
@@ -340,6 +340,19 @@ class HandleEventTests(DjangoTestCase):
         event.status = Event.FAILED
         event.recipient_id = "27820001001"
         event.timestamp = str(timezone.now() + timedelta(days=2))
+        event.data = {
+            "errors": [
+                {
+                    "code": 131026,
+                    "error_data": {
+                        "details": "Message failed to send because more than "
+                        "24 hours have passed since the customer "
+                        "last replied to this number."
+                    },
+                    "title": "Re-engagement message",
+                }
+            ]
+        }
         event.save()
 
         event.refresh_from_db()
@@ -436,6 +449,19 @@ class HandleEventTests(DjangoTestCase):
         event.status = Event.FAILED
         event.recipient_id = "27820001001"
         event.timestamp = timezone.now() + timedelta(days=2)
+        event.data = {
+            "errors": [
+                {
+                    "code": 131026,
+                    "error_data": {
+                        "details": "Message failed to send because more "
+                        "than 24 hours have passed since the customer "
+                        "last replied to this number."
+                    },
+                    "title": "Re-engagement message",
+                }
+            ]
+        }
         event.save()
 
         DeliveryFailure.objects.create(number_of_failures=4, contact_id="27820001001")
@@ -490,6 +516,19 @@ class HandleEventTests(DjangoTestCase):
         event.status = Event.FAILED
         event.recipient_id = "27820001001"
         event.timestamp = timezone.now() + timedelta(days=2)
+        event.data = {
+            "errors": [
+                {
+                    "code": 131026,
+                    "error_data": {
+                        "details": "Message failed to send because "
+                        "more than 24 hours have passed since the "
+                        "customer last replied to this number."
+                    },
+                    "title": "Re-engagement message",
+                }
+            ]
+        }
         event.save()
 
         DeliveryFailure.objects.create(number_of_failures=5, contact_id="27820001001")
@@ -512,12 +551,58 @@ class HandleEventTests(DjangoTestCase):
         event.status = Event.FAILED
         event.recipient_id = "27820001001"
         event.timestamp = timezone.now() + timedelta(days=2)
+        event.data = {
+            "errors": [
+                {
+                    "code": 131026,
+                    "error_data": {
+                        "details": "Message failed to send because more "
+                        "than 24 hours have passed since the customer "
+                        "last replied to this number."
+                    },
+                    "title": "Re-engagement message",
+                }
+            ]
+        }
         event.save()
 
         with patch("eventstore.tasks.rapidpro") as p:
             handle_event(event)
 
         p.create_flow_start.assert_not_called()
+        df = DeliveryFailure.objects.get(contact_id="27820001001")
+        self.assertEqual(df.number_of_failures, 1)
+
+    def test_whatsapp_delivery_failure_excluded_error_code(self):
+        """
+        If it's a failed event and the error code is not in the
+        included_error_codes list, it should not increment
+        the failure count.
+        """
+        event = Event.objects.create()
+        event.fallback_channel = False
+        event.status = Event.FAILED
+        event.recipient_id = "27820001001"
+        event.timestamp = timezone.now() + timedelta(days=2)
+        event.data = {
+            "errors": [
+                {
+                    "code": 131000,
+                    "error_data": {
+                        "details": "Message failed to send due " "to an unknown error."
+                    },
+                    "title": "Something went wrong",
+                }
+            ]
+        }
+        event.save()
+
+        DeliveryFailure.objects.create(number_of_failures=1, contact_id="27820001001")
+
+        with patch("eventstore.whatsapp_actions.increment_failure_count") as p:
+            handle_event(event)
+            p.assert_not_called()
+
         df = DeliveryFailure.objects.get(contact_id="27820001001")
         self.assertEqual(df.number_of_failures, 1)
 

--- a/eventstore/whatsapp_actions.py
+++ b/eventstore/whatsapp_actions.py
@@ -95,6 +95,12 @@ def handle_event(event):
     """
     Triggers all the actions that are required for this event
     """
+
+    included_error_codes = [
+        131026,  # Not a WhatsApp number, outdated app or unaccepted terms
+        131050,  # User has stopped receipt of marketing messages
+    ]
+
     if event.status == Event.FAILED:
         reason = OptOut.WHATSAPP_FAILURE_REASON
         if event.fallback_channel is True:
@@ -103,11 +109,12 @@ def handle_event(event):
             if settings.DISABLE_SMS_FAILURE_OPTOUTS:
                 return
 
-        increment_failure_count(event.recipient_id, event.timestamp, reason)
-
         errors = event.data.get("errors", [])
         for error in errors:
-            if error.get("code") == 131026:
+            error_code = error.get("code")
+            if error_code in included_error_codes:
+                increment_failure_count(event.recipient_id, event.timestamp, reason)
+            if error_code == 131026:
                 update_whatsapp_template_send_status.delay(
                     event.message_id, SMS_CHANNELTYPE
                 )


### PR DESCRIPTION
This PR refines the logic in the handle_event function to improve the accuracy of detecting when a contact is not on WhatsApp by ensuring that we only increment the failure count for specific error codes which indicate a contact is no longer on Whatsapp. 

It utilizes an included_error_codes list containing error codes that suggest the contact is not on WhatsApp or has opted out of messages on that channel. The failure count is only incremented when we get these failed events.

A test was also added to verify that the failure count does not increment when the error code is not in the included_error_codes list.