### PR TITLE
Nluclassifier for feedback labelling

### DIFF
--- a/ndoh_hub/settings.py
+++ b/ndoh_hub/settings.py
@@ -61,6 +61,7 @@ INSTALLED_APPS = (
     "changes",
     "eventstore",
     "aaq",
+    "nluclassifier",
 )
 
 
@@ -108,6 +109,11 @@ LOGGING = {
         "django.db.backends": {
             "level": "ERROR",
             "handlers": ["console"],
+            "propagate": False,
+        },
+        "nluclassifier": {
+            "handlers": ["console"],
+            "level": "INFO",
             "propagate": False,
         },
     },

--- a/ndoh_hub/testsettings.py
+++ b/ndoh_hub/testsettings.py
@@ -30,3 +30,6 @@ AAQ_V2_API_URL = "http://aaq_v2"
 INTENT_CLASSIFIER_URL = "http://intent-classifier"
 INTENT_CLASSIFIER_USER = "nlu_user"
 INTENT_CLASSIFIER_PASS = "nlu_pass"
+
+TURN_URL = "http://turn-test/v1/messages"
+TURN_TOKEN = "test-turn-token"

--- a/ndoh_hub/testsettings.py
+++ b/ndoh_hub/testsettings.py
@@ -30,6 +30,3 @@ AAQ_V2_API_URL = "http://aaq_v2"
 INTENT_CLASSIFIER_URL = "http://intent-classifier"
 INTENT_CLASSIFIER_USER = "nlu_user"
 INTENT_CLASSIFIER_PASS = "nlu_pass"
-
-TURN_URL = "http://turn-test/v1/messages"
-TURN_TOKEN = "test-turn-token"

--- a/ndoh_hub/urls.py
+++ b/ndoh_hub/urls.py
@@ -94,6 +94,7 @@ urlpatterns = [
     path("api/v3/", include(v3router.urls)),
     path("api/v4/", include(v4router.urls)),
     path("api/v5/", include(v5router.urls)),
+    path("nluclassifier/", include("nluclassifier.urls")),
     path(
         "metrics", internal_only(django_prometheus.ExportToDjangoView), name="metrics"
     ),

--- a/nluclassifier/tasks.py
+++ b/nluclassifier/tasks.py
@@ -1,0 +1,119 @@
+import logging
+from urllib.parse import urljoin
+
+import requests
+from celery.exceptions import SoftTimeLimitExceeded
+from django.conf import settings
+from requests.auth import HTTPBasicAuth
+from requests.exceptions import RequestException
+
+from ndoh_hub.celery import app
+
+logger = logging.getLogger(__name__)
+
+CELERY_TASK_OPTIONS = {
+    "autoretry_for": (RequestException, SoftTimeLimitExceeded),
+    "retry_backoff": True,
+    "max_retries": 15,
+    "acks_late": True,
+    "soft_time_limit": 10,
+    "time_limit": 15,
+}
+
+
+@app.task(**CELERY_TASK_OPTIONS)
+def process_feedback_for_labeling(message_id: str, inbound_message: str):
+    """
+    Call the NLU endpoint for feedback classification.
+    LLabel the message in Turn using the detected intent.
+    """
+
+    nlu_label = None
+
+    NLU_URL = settings.INTENT_CLASSIFIER_URL
+    NLU_USER = settings.INTENT_CLASSIFIER_USER
+    NLU_PASS = settings.INTENT_CLASSIFIER_PASS
+    # fmt: off
+    try:
+        nlu_endpoint = urljoin(NLU_URL, "/nlu/feedback/")
+        params = {"question": inbound_message}
+
+        logger.info(f"Calling NLU for message {message_id} at {nlu_endpoint}")
+
+        response = requests.get(
+            nlu_endpoint,
+            params=params,
+            auth=HTTPBasicAuth(NLU_USER, NLU_PASS),
+            timeout=CELERY_TASK_OPTIONS["soft_time_limit"],
+        )
+        response.raise_for_status()
+
+        nlu_label = response.json().get("intent")
+
+        logger.info(f"NLU Intent for {message_id}: {nlu_label}")
+
+    except RequestException as e:
+        logger.warning(
+            f"NLU service failed for message {message_id}. "
+            f"Retrying. Error: {e}"
+            )
+        raise
+    except Exception as e:
+        logger.error(
+            f"NLU non-retriable failure for message {message_id}: "
+            f"{e}"
+            )
+        return
+
+    if nlu_label and nlu_label.lower() in ("compliment", "complaint"):
+
+        TURN_TOKEN = settings.TURN_TOKEN
+        TURN_URL = settings.TURN_URL
+
+        turn_endpoint = urljoin(TURN_URL, f"v1/messages/{message_id}/labels")
+
+        label_payload = {"labels": [nlu_label.lower()]}
+
+        headers = {
+            "Authorization": f"Bearer {TURN_TOKEN}",
+            "Accept": "application/vnd.v1+json",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            logger.info(
+                f"Labeling message {message_id} in Turn at {turn_endpoint} "
+                f"with label: {nlu_label}"
+                )
+
+            turn_response = requests.post(
+                turn_endpoint,
+                json=label_payload,
+                headers=headers,
+                timeout=CELERY_TASK_OPTIONS["soft_time_limit"],
+            )
+
+            turn_response.raise_for_status()
+
+            logger.info(
+                f"Successfully labeled message {message_id} "
+                f"as: {nlu_label}"
+                )
+
+        except RequestException as e:
+
+            logger.warning(
+                f"Turn API failed to label message {message_id}. "
+                f"Retrying. Error: {e}"
+                )
+            raise
+        except Exception as e:
+            logger.error(
+                f"Turn API unrecoverable error for message {message_id}: {e}"
+            )
+            return
+    else:
+        logger.info(
+            f"NLU result was '{nlu_label}' (not 'Compliment' or 'Complaint'). "
+            f"No Turn label applied for message {message_id}."
+            )

--- a/nluclassifier/tests/test_tasks.py
+++ b/nluclassifier/tests/test_tasks.py
@@ -1,0 +1,168 @@
+import logging
+from unittest import mock
+from urllib.parse import urljoin
+
+import requests.exceptions
+from django.conf import settings
+from django.test import TestCase
+
+from nluclassifier.tasks import process_feedback_for_labeling
+
+logger = logging.getLogger(__name__)
+
+
+# fmt: off
+class NLUClassifierTaskTests(TestCase):
+    """
+    Tests for the Celery task that handles NLU classification
+    and Turn message labeling. The tests verify API calls and
+    ensure RequestExceptions are re-raised for Celery's autoretry
+    """
+
+    def setUp(self):
+        self.settings = settings
+
+        self.message_id = "12345"
+        self.inbound_message = "I am not happy with your service."
+
+        self.expected_intent = "COMPLAINT"
+
+    def test_successful_classification_and_labeling(self):
+        """
+        Tests the end-to-end flow where NLU classifies the message and
+        Turn successfully applies the label
+        """
+        nlu_success_mock = mock.Mock(status_code=200)
+        nlu_success_mock.json.return_value = {
+            "intent": self.expected_intent,
+            "model_version": "2025-09-29-v1",
+            "parent_label": "FEEDBACK",
+            "probability": 0.3805,
+            "review_status": "NEEDS_REVIEW",
+        }
+        nlu_success_mock.raise_for_status.return_value = None
+
+        turn_success_mock = mock.Mock(status_code=202)
+        turn_success_mock.raise_for_status.return_value = None
+
+        with (
+            mock.patch("requests.get") as mock_get,
+            mock.patch("requests.post") as mock_post,
+        ):
+
+            mock_get.return_value = nlu_success_mock
+            mock_post.return_value = turn_success_mock
+
+            result = process_feedback_for_labeling(
+                self.message_id, self.inbound_message
+            )
+
+            expected_nlu_endpoint = urljoin(
+                self.settings.INTENT_CLASSIFIER_URL, "/nlu/feedback/"
+            )
+
+            self.assertEqual(mock_get.call_count, 1)
+            nlu_call_args = mock_get.call_args
+            self.assertEqual(nlu_call_args[0][0], expected_nlu_endpoint)
+            self.assertEqual(
+                nlu_call_args[1]["auth"],
+                (
+                    self.settings.INTENT_CLASSIFIER_USER,
+                    self.settings.INTENT_CLASSIFIER_PASS,
+                ),
+            )
+            self.assertEqual(
+                nlu_call_args[1]["params"]["question"], self.inbound_message
+            )
+
+            self.assertEqual(mock_post.call_count, 1)
+            turn_call_args = mock_post.call_args
+            self.assertIn(
+                f"messages/{self.message_id}/labels",
+                turn_call_args[0][0]
+                )
+            self.assertEqual(
+                turn_call_args[1]["headers"]["Authorization"],
+                f"Bearer {self.settings.TURN_TOKEN}",
+            )
+
+            turn_payload = turn_call_args[1]["json"]
+            self.assertEqual(
+                turn_payload["labels"],
+                [self.expected_intent.lower()]
+                )
+
+            self.assertTrue(result is None)
+
+    def test_nlu_api_failure_raises_exception_for_celery_retry(self):
+        """
+        Tests that if the NLU API returns a failure,
+        a RequestException is raised
+        """
+        nlu_fail_mock = mock.Mock(status_code=404)
+        error = requests.exceptions.HTTPError("404 Not Found")
+        nlu_fail_mock.raise_for_status.side_effect = error
+
+        with (
+            mock.patch("requests.get") as mock_get,
+            mock.patch("requests.post") as mock_post,
+            self.assertLogs(
+                "nluclassifier.tasks", level="WARNING") as log_context,
+        ):
+
+            mock_get.return_value = nlu_fail_mock
+
+            with self.assertRaises(requests.exceptions.HTTPError):
+                process_feedback_for_labeling(
+                    self.message_id, self.inbound_message)
+
+            self.assertEqual(mock_get.call_count, 1)
+
+            self.assertEqual(mock_post.call_count, 0)
+
+            self.assertTrue(
+                any(
+                    "NLU service failed for message" in output
+                    for output in log_context.output
+                )
+            )
+
+    def test_no_label_applied_on_unhandled_intent(self):
+        """
+        Tests that if NLU returns an intent that is not
+        'compliment' or 'complaint'.
+        No Turn API call is made.
+        """
+        nlu_success_mock = mock.Mock(status_code=200)
+
+        nlu_success_mock.json.return_value = {
+            "intent": "None",
+            "model_version": "2025-09-29-v1",
+            "parent_label": "SENSITIVE_EXIT",
+            "probability": 0.3357,
+            "review_status": "NEEDS_REVIEW",
+        }
+        nlu_success_mock.raise_for_status.return_value = None
+
+        with (
+            mock.patch("requests.get") as mock_get,
+            mock.patch("requests.post") as mock_post,
+            self.assertLogs(
+                "nluclassifier.tasks", level="INFO") as log_context,
+        ):
+
+            mock_get.return_value = nlu_success_mock
+
+            result = process_feedback_for_labeling(
+                self.message_id, self.inbound_message
+            )
+
+            self.assertEqual(mock_get.call_count, 1)
+
+            self.assertEqual(mock_post.call_count, 0)
+
+            self.assertTrue(
+                any("No Turn label applied" in output
+                    for output in log_context.output)
+            )
+            self.assertTrue(result is None)

--- a/nluclassifier/tests/test_tasks.py
+++ b/nluclassifier/tests/test_tasks.py
@@ -65,13 +65,6 @@ class NLUClassifierTaskTests(TestCase):
             nlu_call_args = mock_get.call_args
             self.assertEqual(nlu_call_args[0][0], expected_nlu_endpoint)
             self.assertEqual(
-                nlu_call_args[1]["auth"],
-                (
-                    self.settings.INTENT_CLASSIFIER_USER,
-                    self.settings.INTENT_CLASSIFIER_PASS,
-                ),
-            )
-            self.assertEqual(
                 nlu_call_args[1]["params"]["question"], self.inbound_message
             )
 

--- a/nluclassifier/tests/test_tasks.py
+++ b/nluclassifier/tests/test_tasks.py
@@ -120,6 +120,47 @@ class NLUClassifierTaskTests(TestCase):
                 )
             )
 
+    def test_turn_api_failure_raises_exception_for_retry(self):
+        """
+        Tests that if NLU succeeds but the Turn API fails,
+        a RequestException is rraised to trigger a retry.
+        """
+        nlu_success_mock = mock.Mock(status_code=200)
+        nlu_success_mock.json.return_value = {
+            "intent": self.expected_intent,
+            "model_version": "2025-09-29-v1",
+            "parent_label": "FEEDBACK",
+            "probability": 0.3805,
+            "review_status": "NEEDS_REVIEW",
+        }
+        nlu_success_mock.raise_for_status.return_value = None
+
+        turn_fail_mock = mock.Mock(status_code=500)
+        error = requests.exceptions.HTTPError("500 Server Error")
+        turn_fail_mock.raise_for_status.side_effect = error
+
+        with (
+            mock.patch("requests.get") as mock_get,
+            mock.patch("requests.post") as mock_post,
+            self.assertLogs(
+                "nluclassifier.tasks", level="WARNING") as log_context,
+        ):
+            mock_get.return_value = nlu_success_mock
+            mock_post.return_value = turn_fail_mock
+
+            with self.assertRaises(requests.exceptions.HTTPError):
+                process_feedback_for_labeling(
+                    self.message_id, self.inbound_message)
+
+            self.assertEqual(mock_get.call_count, 1)
+
+            self.assertEqual(mock_post.call_count, 1)
+
+            self.assertTrue(
+                any("Turn API failed to label message" in output
+                    for output in log_context.output)
+            )
+
     def test_no_label_applied_on_unhandled_intent(self):
         """
         Tests that if NLU returns an intent that is not

--- a/nluclassifier/tests/test_views.py
+++ b/nluclassifier/tests/test_views.py
@@ -1,0 +1,104 @@
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+# fmt: off
+class NLUWebhookTests(APITestCase):
+    def setUp(self):
+        self.url = reverse("label_feedback")
+
+        self.username = "testuser"
+        self.password = "password"
+        self.user = User.objects.create_user(
+            self.username, password=self.password)
+
+        self.message_id = "turn-messageid-123"
+        self.inbound_message = "I love this service, it is great."
+        self.valid_data = {
+            "message_id": self.message_id,
+            "inbound_message": self.inbound_message,
+        }
+
+    def test_unauthenticated_request_is_unauthorized(self):
+        """
+        An unauthenticated request should be rejected with 401 Unauthorized
+        """
+        response = self.client.post(self.url, self.valid_data)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            "Authentication credentials were not provided.",
+            response.json().get("detail", ""),
+        )
+
+    @patch("nluclassifier.views.process_feedback_for_labeling.delay")
+    def test_auth_valid_params_task_202(
+        self, mock_delay
+    ):
+        """
+        An authenticated POST request with required body parameters
+        should queue the Celery task and return 202
+        """
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(self.url, self.valid_data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
+        mock_delay.assert_called_once_with(
+            self.message_id, self.inbound_message)
+
+        self.assertEqual(
+            response.json()["status"],
+            "Feedback labeling process initiated successfully.",
+        )
+
+    @patch("nluclassifier.views.process_feedback_for_labeling.delay")
+    def test_authenticated_request_missing_required_params_returns_400(
+        self, mock_delay
+    ):
+        """
+        An authenticated request missing required body parameters should return
+        400 Bad Request and not queue the task.
+        """
+        self.client.force_authenticate(user=self.user)
+
+        response_missing_id = self.client.post(
+            self.url, {"inbound_message": self.inbound_message}, format="json"
+        )
+        self.assertEqual(
+            response_missing_id.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            "Missing 'message_id' or 'inbound_message' parameter",
+            response_missing_id.json()["error"],
+        )
+
+        response_missing_msg = self.client.post(
+            self.url, {"message_id": self.message_id}, format="json"
+        )
+        self.assertEqual(
+            response_missing_msg.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            "Missing 'message_id' or 'inbound_message' parameter",
+            response_missing_msg.json()["error"],
+        )
+
+        mock_delay.assert_not_called()
+
+    @patch("nluclassifier.views.process_feedback_for_labeling.delay")
+    def test_method_not_allowed(self, mock_delay):
+        """
+        Check that Only POST method is allowed otherwise 405 is returned
+        """
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(self.url, data=self.valid_data)
+
+        self.assertEqual(
+            response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+        mock_delay.assert_not_called()

--- a/nluclassifier/tests/test_views.py
+++ b/nluclassifier/tests/test_views.py
@@ -12,7 +12,7 @@ class NLUWebhookTests(APITestCase):
         self.url = reverse("label_feedback")
 
         self.username = "testuser"
-        self.password = "password"
+        self.password = "password"  # noqa: S105
         self.user = User.objects.create_user(
             self.username, password=self.password)
 

--- a/nluclassifier/urls.py
+++ b/nluclassifier/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+
+from . import views
+
+# fmt: off
+urlpatterns = [
+    path(
+        "label/feedback/",
+        views.LabelFeedbackView.as_view(),
+        name="label_feedback"
+    ),
+]

--- a/nluclassifier/views.py
+++ b/nluclassifier/views.py
@@ -1,0 +1,51 @@
+import logging
+
+from django.http import HttpRequest
+from rest_framework import generics, permissions, status
+from rest_framework.response import Response
+
+from .tasks import process_feedback_for_labeling
+
+logger = logging.getLogger(__name__)
+
+
+class LabelFeedbackView(generics.GenericAPIView):
+    """
+    Handles inbound messages via a POST request
+    Classifies the message using NLU and labels it in Turn
+
+    Access requires authentication via permissions.IsAuthenticated
+    """
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def post(self, request: HttpRequest, *args, **kwargs):
+        """
+        Processes the POST request from RapidPro
+        """
+
+        message_id = request.data.get("message_id")
+        inbound_message = request.data.get("inbound_message")
+
+        if not message_id or not inbound_message:
+            logger.error(
+                "Received request missing 'message_id' or "
+                "'inbound_message' in POST body."
+            )
+            return Response(
+                {
+                    "error": (
+                        "Missing 'message_id' or "
+                        "'inbound_message' parameter in POST body."
+                    ),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        process_feedback_for_labeling.delay(message_id, inbound_message)
+
+        logger.info(f"Queued NLU task for message ID: {message_id}")
+        return Response(
+            {"status": "Feedback labeling process initiated successfully."},
+            status=status.HTTP_202_ACCEPTED,
+        )


### PR DESCRIPTION
This pull request add and endpoint for processing user feedback (complaints/compliments) and classifying/labeling the message in Turn.
1. Endpoint is `/label/feedback`
2. App receives a POST request from Rapidpro with `message_id` and `inbound_message` in the body.
3. It starts the celery task `process_feedback_for_labeling` which calls our NLU service for intent classification.
4. The app then retrieves the intent and calls Turn to label the message if the intent is a `COMPLIMENT` or a `COMPLAINT`.

NB: There were some black and flake8 conflicts where black would condense ta block in a single line but it would then be flagged by flake8 for being over the limit. 
To bypass that, I added an `#fmt: off` in some places so black knows to skip those lines.