### PR TITLE
babyloss nlu

### DIFF
--- a/eventstore/tasks.py
+++ b/eventstore/tasks.py
@@ -820,13 +820,10 @@ def route_nlu_result(
     If the message is SMS, it processes feedback for labeling.
     """
     if is_babyloss_intent is True:
-        label_whatsapp_message.s("BABYLOSS", message_id).delay()
+        label_whatsapp_message.delay("BABYLOSS", message_id)
         return
 
-    if is_sms is False:
-        return
-
-    if is_sms is True:
+    elif is_sms is True:
         process_feedback_for_labeling.delay(message_id, inbound_message)
         return
 

--- a/eventstore/tasks.py
+++ b/eventstore/tasks.py
@@ -840,7 +840,6 @@ def route_nlu_result(
     time_limit=15,
 )
 def label_whatsapp_message(label, message_id):
-
     headers = {
         "Authorization": f"Bearer {settings.TURN_TOKEN}",
         "content-type": "application/json",

--- a/eventstore/tasks.py
+++ b/eventstore/tasks.py
@@ -41,6 +41,7 @@ from eventstore.models import (
 )
 from ndoh_hub.celery import app
 from ndoh_hub.utils import get_random_date, get_today, rapidpro, send_slack_message
+from nluclassifier.tasks import process_feedback_for_labeling
 from registrations.models import JembiSubmission
 
 
@@ -792,14 +793,42 @@ def process_whatsapp_template_send_status():
 def get_inbound_intent(text):
     params = {"question": text}
     response = requests.get(
-        urljoin(settings.INTENT_CLASSIFIER_URL, "/nlu/"),
+        urljoin(settings.INTENT_CLASSIFIER_URL, "/nlu/babyloss/"),
         params=params,
         auth=HTTPBasicAuth(
             settings.INTENT_CLASSIFIER_USER, settings.INTENT_CLASSIFIER_PASS
         ),
     )
     response.raise_for_status()
-    return response.json()["intent"]
+    return response.json()["babyloss"]
+
+
+@app.task(
+    autoretry_for=(RequestException, SoftTimeLimitExceeded),
+    retry_backoff=True,
+    max_retries=15,
+    acks_late=True,
+    soft_time_limit=10,
+    time_limit=15,
+)
+def route_nlu_result(
+    is_babyloss_intent: bool, message_id: str, is_sms: bool, inbound_message: str
+):
+    """
+    Receives the boolean result from the babyloss NLU endpoint and routes to the next step.
+    If babyloss intent is True, it labels the message as BABYLOSS.
+    If the message is SMS, it processes feedback for labeling.
+    """
+    if is_babyloss_intent is True:
+        label_whatsapp_message.s("BABYLOSS", message_id).delay()
+        return
+
+    if is_sms is False:
+        return
+
+    if is_sms is True:
+        process_feedback_for_labeling.delay(message_id, inbound_message)
+        return
 
 
 @app.task(
@@ -811,6 +840,7 @@ def get_inbound_intent(text):
     time_limit=15,
 )
 def label_whatsapp_message(label, message_id):
+
     headers = {
         "Authorization": f"Bearer {settings.TURN_TOKEN}",
         "content-type": "application/json",

--- a/eventstore/tests/test_whatsapp_actions.py
+++ b/eventstore/tests/test_whatsapp_actions.py
@@ -205,45 +205,116 @@ class HandleInboundTests(DjangoTestCase):
             handle.assert_not_called()
 
     @responses.activate
-    def test_intent_classification(self):
-        inbound_text = "The test inbound message body"
+    def test_babyloss_intent_is_true_wa(self):
+        inbound_text = "The test babyloss message"
+        message_id = "msg-id-babyloss"
+
         responses.add(
             responses.GET,
-            "http://intent-classifier/nlu/",
+            "http://intent-classifier/nlu/babyloss/",
             json={
-                "question": "The test inbound message body",
-                "intent": "Test Label",
-                "confidence": 90,
+                "babyloss": True,
             },
         )
 
         responses.add(
-            responses.POST, "http://turn/v1/messages/msg-id-1/labels", json={}
+            responses.POST, f"http://turn/v1/messages/{message_id}/labels", json={}
         )
 
         message = Mock()
         message.has_label.return_value = False
-        message.id = "msg-id-1"
+        message.id = message_id
         message.type = "text"
+        message.fallback_channel = False
         message.data = {"text": {"body": inbound_text}}
 
         handle_inbound(message)
 
-        [intent_call, label_call] = responses.calls
-
+        intent_call = next(
+            c for c in responses.calls if "/nlu/babyloss/" in c.request.url
+        )
         self.assertEqual(intent_call.request.params, {"question": inbound_text})
+
+        label_call = next(c for c in responses.calls if "labels" in c.request.url)
         self.assertEqual(
-            intent_call.request.headers["Authorization"],
-            "Basic bmx1X3VzZXI6bmx1X3Bhc3M=",
+            json.loads(label_call.request.body),
+            {"labels": ["BABYLOSS"]},
+            "The message should be labeled 'BABYLOSS' when intent is True.",
+        )
+        self.assertEqual(len(responses.calls), 3)
+
+    @responses.activate
+    def test_not_babyloss_sms_channel(self):
+        inbound_text = "The test complaint message"
+        message_id = "msg-id-sms-feedback"
+        contact_id = "27820001002"
+
+        responses.add(
+            responses.GET,
+            "http://intent-classifier/nlu/babyloss/",
+            json={"babyloss": False},
         )
 
-        self.assertEqual(
-            json.loads(label_call.request.body), {"labels": ["Test Label"]}
+        responses.add(
+            responses.GET,
+            "http://intent-classifier/nlu/feedback/",
+            json={"intent": "Complaint", "confidence": 95},
         )
-        self.assertEqual(
-            label_call.request.headers["Authorization"],
-            "Bearer turn-token",
+
+        responses.add(
+            responses.POST, f"http://turn/v1/messages/{message_id}/labels", json={}
         )
+
+        message = Mock()
+        message.has_label.return_value = False
+        message.id = message_id
+        message.type = "text"
+        message.contact_id = contact_id
+        message.fallback_channel = True
+        message.data = {"text": {"body": inbound_text}}
+
+        handle_inbound(message)
+
+        self.assertEqual(len(responses.calls), 3)
+
+        feedback_call = next(
+            c for c in responses.calls if "/nlu/feedback/" in c.request.url
+        )
+        self.assertEqual(feedback_call.request.params, {"question": inbound_text})
+
+        label_call = next(c for c in responses.calls if "labels" in c.request.url)
+        self.assertEqual(
+            json.loads(label_call.request.body),
+            {"labels": ["complaint"]},
+            "The message should be labeled 'complaint'",
+        )
+
+    @responses.activate
+    def test_not_babyloss_whatsapp_channel_do_nothing(self):
+        inbound_text = "The test compliment message"
+        message_id = "msg-id-wa-feedback"
+        contact_id = "27820001002"
+
+        responses.add(
+            responses.GET,
+            "http://intent-classifier/nlu/babyloss/",
+            json={"babyloss": False},
+        )
+
+        message = Mock()
+        message.has_label.return_value = False
+        message.id = message_id
+        message.type = "text"
+        message.contact_id = contact_id
+        message.fallback_channel = False
+        message.data = {"text": {"body": inbound_text}}
+
+        handle_inbound(message)
+
+        self.assertEqual(len(responses.calls), 2)
+
+        nlu_call = next(c for c in responses.calls if "/nlu/babyloss/" in c.request.url)
+        self.assertEqual(nlu_call.request.params, {"question": inbound_text})
 
     @responses.activate
     @override_settings(INTENT_CLASSIFIER_URL=None)

--- a/eventstore/whatsapp_actions.py
+++ b/eventstore/whatsapp_actions.py
@@ -6,7 +6,7 @@ from eventstore.tasks import (
     async_create_flow_start,
     get_inbound_intent,
     get_rapidpro_contact_by_msisdn,
-    label_whatsapp_message,
+    route_nlu_result,
     send_helpdesk_response_to_dhis2,
     update_rapidpro_contact,
 )
@@ -62,9 +62,10 @@ def handle_inbound(message):
     if settings.INTENT_CLASSIFIER_URL and message.type == "text":
         text = message.data["text"]["body"]
         if text.lower() != "yes":
+            is_sms = message.fallback_channel
             chain(
                 get_inbound_intent.s(),
-                label_whatsapp_message.s(message.id),
+                route_nlu_result.s(message.id, is_sms, text),
             ).delay(text)
 
 


### PR DESCRIPTION
This PR updates existing NLU logic by calling a new babyloss endpoint and therefore prioritizing Babyloss intent for inbound messages. 
`handle_inbound()` is updated to celery tasks when an inbound is received. 
1. `get_inbound_intent` hits the NLU endpoint /nlu/babyloss/ which returns a booloean result ({"babyloss": True/False}) as per [documentation](https://docs.google.com/document/d/17Bo7rzQtI_a4ubNnV1XSaBI3NEwABvJHvcOhsxEPX1c/edit?tab=t.blzrb09cfktk#heading=h.2fmt26cvnrf6).
2. `route_nlu_result` task evaluates the result and checks the message channel (`is_sms`)
If `babyloss: True`, it triggers the `Babyloss` label function.
If `babyloss: False` and WA, the process terminates else if SMS, we classify the intent (complaint or compliment) and label the message.