### PR TITLE
Update script to handle beta testing users and update opted in logic

### DIFF
--- a/scripts/migrate_to_turn/fetch_rapidpro_contacts.py
+++ b/scripts/migrate_to_turn/fetch_rapidpro_contacts.py
@@ -22,6 +22,10 @@ START_DATE = "2025-11-01 01:13:06"
 END_DATE = "2026-01-22 19:13:06"
 LIMIT = 1000
 INCLUDE_OPTED_OUT = False
+# We want to import beta testing users as opted out and give them the chance to opt in.
+IMPORT_AS_OPTED_OUT = True
+# This is to identify invited users and schedule the invite message.
+MIGRATION_KEY = "beta_testing_batch_1"
 
 MSISDN_FILTER = (
     os.environ.get("MSISDN_FILTER", "").split(",")
@@ -48,7 +52,7 @@ FIELD_MAPPING = {
     "education": {"turn_name": "education", "type": "custom"},
     "opted_out": {
         "turn_name": "opted_in",
-        "process": process_opted_in,
+        "process": lambda value: process_opted_in(value, IMPORT_AS_OPTED_OUT),
         "type": "custom",
     },
     "prebirth_messaging": {
@@ -83,6 +87,7 @@ NEW_TURN_FIELD_MAPPING = {
     "pregnancy_loss_status": {"process": process_pregnancy_loss_status},
     "is_new_user": {"process": lambda contact: "no"},
     "babies": {"process": get_user_babies},
+    "migration_key": {"process": lambda contact: MIGRATION_KEY},
 }
 
 

--- a/scripts/migrate_to_turn/process_fields.py
+++ b/scripts/migrate_to_turn/process_fields.py
@@ -29,7 +29,10 @@ def process_datetime(value):
         return value
 
 
-def process_opted_in(value):
+def process_opted_in(value, import_as_opted_out=False):
+    if import_as_opted_out:
+        return "false"
+
     if not value:
         return "true"
 

--- a/scripts/migrate_to_turn/tests/test_fetch_rapidpro_contacts.py
+++ b/scripts/migrate_to_turn/tests/test_fetch_rapidpro_contacts.py
@@ -39,6 +39,46 @@ class FakeClient:
 
 
 class FetchRapidproContactsTests(TestCase):
+    def test_get_field_data_uses_opted_out_when_import_override_is_false(self):
+        with patch.object(fetch_rapidpro_contacts, "IMPORT_AS_OPTED_OUT", False):
+            contact_opted_in = type(
+                "Contact",
+                (),
+                {
+                    "fields": {"opted_out": "FALSE"},
+                    "name": "Alice",
+                    "language": "eng",
+                    "urns": ["whatsapp:27820000000"],
+                    "modified_on": datetime(2025, 1, 3, 12, 0, 0, tzinfo=pytz.utc),
+                },
+            )()
+            contact_opted_out = type(
+                "Contact",
+                (),
+                {
+                    "fields": {"opted_out": "TRUE"},
+                    "name": "Bob",
+                    "language": "eng",
+                    "urns": ["whatsapp:27820000001"],
+                    "modified_on": datetime(2025, 1, 3, 12, 0, 0, tzinfo=pytz.utc),
+                },
+            )()
+
+            self.assertEqual(
+                fetch_rapidpro_contacts.get_field_data(contact_opted_in)["opted_in"],
+                "true",
+            )
+            self.assertEqual(
+                fetch_rapidpro_contacts.get_field_data(contact_opted_out)["opted_in"],
+                "false",
+            )
+            self.assertEqual(
+                fetch_rapidpro_contacts.get_field_data(contact_opted_in)[
+                    "migration_key"
+                ],
+                fetch_rapidpro_contacts.MIGRATION_KEY,
+            )
+
     def test_fetch_rapidpro_contacts_writes_csv(self):
         contact = type(
             "Contact",
@@ -74,6 +114,7 @@ class FetchRapidproContactsTests(TestCase):
             with (
                 patch.object(fetch_rapidpro_contacts, "START_DATE", start_date),
                 patch.object(fetch_rapidpro_contacts, "END_DATE", end_date),
+                patch.object(fetch_rapidpro_contacts, "IMPORT_AS_OPTED_OUT", True),
             ):
                 fetch_rapidpro_contacts.fetch_rapidpro_contacts(client)
 
@@ -101,6 +142,7 @@ class FetchRapidproContactsTests(TestCase):
             "pregnancy_loss_status",
             "is_new_user",
             "babies",
+            "migration_key",
             "urn",
         ]
 
@@ -117,7 +159,7 @@ class FetchRapidproContactsTests(TestCase):
             "clinic_code": "123",
             "referred_number": "+27123",
             "education": "secondary",
-            "opted_in": "true",
+            "opted_in": "false",
             "pregnancy_message_status": "true",
             "baby_message_status": "true",
             "minor_healthcare_consent": "true",
@@ -128,6 +170,7 @@ class FetchRapidproContactsTests(TestCase):
             "pregnancy_loss_status": "",
             "is_new_user": "no",
             "babies": fetch_rapidpro_contacts.get_user_babies(contact),
+            "migration_key": fetch_rapidpro_contacts.MIGRATION_KEY,
             "urn": "27820000000",
         }
 

--- a/scripts/migrate_to_turn/tests/test_process_fields.py
+++ b/scripts/migrate_to_turn/tests/test_process_fields.py
@@ -96,6 +96,14 @@ class ProcessOptedInTests(TestCase):
         self.assertEqual(process_opted_in(True), "false")
         self.assertEqual(process_opted_in(False), "true")
 
+    def test_import_as_opted_out_forces_false(self):
+        """
+        Import override always sets opted_in to false
+        """
+        for value in (None, "", "FALSE", "TRUE", False, True):
+            with self.subTest(value=value):
+                self.assertEqual(process_opted_in(value, True), "false")
+
 
 class ProcessTruthyTests(TestCase):
     def test_none_returns_false(self):


### PR DESCRIPTION
This pull request introduces support for importing beta testing users as opted out during the migration process and adds a migration key to identify the batch of migrated users. The changes ensure that the opt-in status can be overridden for specific migrations and that tests cover this new behavior.

Migration logic enhancements:

* Added `IMPORT_AS_OPTED_OUT` and `MIGRATION_KEY` flags in `fetch_rapidpro_contacts.py` to allow importing users as opted out and tagging them with a migration batch key.
* Modified the `process_opted_in` function to accept an override parameter, ensuring users are imported as opted out when required.
* Updated the contact field processing logic to use the override flag and include the migration key in user data. [[1]](diffhunk://#diff-90d1cb37021f990ff16ee94cc512f7f6e0958321f6917c4fd9604612343a9296L51-R55) [[2]](diffhunk://#diff-90d1cb37021f990ff16ee94cc512f7f6e0958321f6917c4fd9604612343a9296R90)

Testing improvements:

* Added and updated tests in `test_fetch_rapidpro_contacts.py` to verify that the opt-in override and migration key are correctly applied and exported. [[1]](diffhunk://#diff-a7e642d9a78182177a19755fff3009b414947cf3e4f1e78c556343d775b8cab6R42-R81) [[2]](diffhunk://#diff-a7e642d9a78182177a19755fff3009b414947cf3e4f1e78c556343d775b8cab6R117) [[3]](diffhunk://#diff-a7e642d9a78182177a19755fff3009b414947cf3e4f1e78c556343d775b8cab6R145) [[4]](diffhunk://#diff-a7e642d9a78182177a19755fff3009b414947cf3e4f1e78c556343d775b8cab6L120-R162) [[5]](diffhunk://#diff-a7e642d9a78182177a19755fff3009b414947cf3e4f1e78c556343d775b8cab6R173)
* Added a test in `test_process_fields.py` to confirm that the override always sets opted_in to false, regardless of input.